### PR TITLE
[FEATURE]: Lowercase sql comparisons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ serve: ## Serve the node server statically (no restarting on file changes)
 	node -r dotenv/config ./dist/server.js
 
 typecheck: ## Check for type errors that would cause failures to build
-	tsc --noEmit --incremental false
+	npx tsc --noEmit --incremental false
 
 # |----------- DATABASE MIGRATION SCRIPTS ---------|
 generate-migration: ## Generate a new migration file with name=MIGRATION_NAME and using config for ENV

--- a/src/DAO/UserDAO.ts
+++ b/src/DAO/UserDAO.ts
@@ -31,13 +31,13 @@ export default class UserDAO {
         return findFn(query);
     }
 
-    public async findUserWithPassword(query: Partial<User>): Promise<User | undefined> {
+    public async findUserWithPasswordByEmail(email: string): Promise<User | undefined> {
         return await this.userDb
             .createQueryBuilder("user")
             .select("user.id")
             .addSelect("user.password")
             .addSelect("user.email")
-            .where(query)
+            .where("user.email ILIKE :email", { email })
             .getOne();
     }
 

--- a/src/authentication/auth.ts
+++ b/src/authentication/auth.ts
@@ -27,7 +27,7 @@ export async function signUpAuthentication(
 ): Promise<void> {
     try {
         logger.debug("sign up strategy");
-        const user = await userDAO.findUserWithPassword({ email });
+        const user = await userDAO.findUserWithPasswordByEmail(email);
         if (!user) {
             logger.debug("no existing user with that email");
             const hashedPass = await generateHashedPassword(password);
@@ -58,7 +58,7 @@ export async function signInAuthentication(
     try {
         logger.debug("sign in strategy");
         // Will throw EntityNotFoundError if user is not found
-        const user = await userDAO.findUserWithPassword({ email });
+        const user = await userDAO.findUserWithPasswordByEmail(email);
         if (user) {
             logger.debug("found user with matching email");
             const validPassword = user.password && (await isPasswordMatching(password, user.password));

--- a/tests/integration/AuthRoutes.test.ts
+++ b/tests/integration/AuthRoutes.test.ts
@@ -120,6 +120,16 @@ describe("Auth API endpoints", () => {
             expect(body.lastLoggedIn).toBeDefined();
         });
 
+        it("should successfully login the user with case-insensitive email matching", async () => {
+            const { body } = await request(app)
+              .post("/auth/login")
+              .send({ email: testUser.email.toLocaleUpperCase(), password: testUser.password })
+              .expect(200);
+            expect(body.email).toEqual(testUser.email);
+            expect(body).not.toHaveProperty("password");
+            expect(body.lastLoggedIn).toBeDefined();
+        });
+
         it("should use the most recently logged in user credentials in the session (if somehow someone logs into a new user from an existing session", async () => {
             const sessionCheckFn = (agent: request.SuperTest<request.Test>) =>
                 agent.get("/auth/session_check").expect(200);

--- a/tests/integration/AuthRoutes.test.ts
+++ b/tests/integration/AuthRoutes.test.ts
@@ -76,7 +76,7 @@ describe("Auth API endpoints", () => {
             // Create user directly in db, with just email
             await userDAO.createUsers([{ email: testUser.email }]);
 
-            const noPassUser = await userDAO.findUserWithPassword({ email: testUser.email });
+            const noPassUser = await userDAO.findUserWithPasswordByEmail(testUser.email);
             expect(noPassUser!.password).toBeFalsy();
 
             // Sign up user
@@ -85,7 +85,7 @@ describe("Auth API endpoints", () => {
             expect(body.lastLoggedIn).toBeDefined();
 
             // Check that user password is now set
-            const updatedUser = await userDAO.findUserWithPassword({ email: testUser.email });
+            const updatedUser = await userDAO.findUserWithPasswordByEmail(testUser.email);
             expect(updatedUser!.password).toBeDefined();
         });
         it("should not allow signing up with the same email for an existing user that already has a password", async () => {

--- a/tests/unit/DAO/userDAO.test.ts
+++ b/tests/unit/DAO/userDAO.test.ts
@@ -105,7 +105,7 @@ describe("UserDAO", () => {
         });
     });
 
-    describe("findUserWithPassword", () => {
+    describe("findUserWithPasswordByEmail", () => {
         it("should pass a query object to the find method and return an array", async () => {
             const getOneFn = jest.fn().mockResolvedValueOnce(testUser);
             const whereFn = jest.fn();
@@ -119,10 +119,10 @@ describe("UserDAO", () => {
             };
             mockUserDb.createQueryBuilder.mockReturnValueOnce(findUserWithPasswordChain);
 
-            const condition = { password: testUser.password };
-            const res = await userDAO.findUserWithPassword(condition);
+            const condition = testUser.email ;
+            const res = await userDAO.findUserWithPasswordByEmail(condition);
 
-            expect(whereFn).toBeCalledWith(condition);
+            expect(whereFn).toBeCalledWith("user.email ILIKE :email", { email: testUser.email });
             expect(addSelectFn).toBeCalledWith("user.password");
             expect(addSelectFn).toBeCalledWith("user.email");
             expect(selectFn).toBeCalledWith("user.id");

--- a/tests/unit/api/middlewares/AuthenticationHandler.test.ts
+++ b/tests/unit/api/middlewares/AuthenticationHandler.test.ts
@@ -16,7 +16,7 @@ declare module "express-session" {
 }
 
 const mockUserDAO = {
-    findUserWithPassword: jest.fn(),
+    findUserWithPasswordByEmail: jest.fn(),
     updateUser: jest.fn(),
 };
 
@@ -32,7 +32,7 @@ describe("Authentication middleware", () => {
     describe("LoginHandler", () => {
         it("should serialize the user and return the next function if sign in was successful", async () => {
             const testUserWithPass = { ...testUser, password: await hash(testUser.password!, 1) };
-            mockUserDAO.findUserWithPassword.mockResolvedValueOnce(testUserWithPass);
+            mockUserDAO.findUserWithPasswordByEmail.mockResolvedValueOnce(testUserWithPass);
             mockUserDAO.updateUser.mockResolvedValueOnce(testUserWithPass);
             const next: NextFunction = jest.fn();
             const request: Pick<Request, "body" | "session"> = {
@@ -69,8 +69,8 @@ describe("Authentication middleware", () => {
         it("should serialize the user and return the next function if sign up was successful", async () => {
             const passwordlessUser = { ...testUser };
             delete passwordlessUser.password;
-            mockUserDAO.findUserWithPassword.mockResolvedValueOnce(passwordlessUser);
-            mockUserDAO.updateUser.mockResolvedValueOnce(testUser);
+            mockUserDAO.findUserWithPasswordByEmail.mockResolvedValueOnce(passwordlessUser);
+            mockUserDAO.updateUser.mockResolvedValueOnce(passwordlessUser);
             const next: NextFunction = jest.fn();
             const request: Pick<Request, "body" | "session"> = {
                 body: { email: testUser.email, password: testUser.password! },
@@ -86,7 +86,7 @@ describe("Authentication middleware", () => {
             expect(request.session.user).toEqual(testUser.id);
         });
         it("should return the original error if the signup method returns an error", async () => {
-            mockUserDAO.findUserWithPassword.mockResolvedValueOnce(testUser);
+            mockUserDAO.findUserWithPasswordByEmail.mockResolvedValueOnce(testUser);
             const next: NextFunction = jest.fn();
             const request: Pick<Request, "body" | "session"> = {
                 body: { email: testUser.email, password: testUser.password! },

--- a/tests/unit/authentication/auth.test.ts
+++ b/tests/unit/authentication/auth.test.ts
@@ -19,10 +19,13 @@ import { MockObj } from "../DAO/daoHelpers";
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 const testUser = UserFactory.getUser("j@gm.com", "Jatheesh", undefined, Role.OWNER);
+const hashedPassword = generateHashedPassword(testUser.password!);
+const passwordlessUser = new User({ ...testUser });
+delete passwordlessUser.password;
 
 const mockUserDAO: MockObj = {
     getUserById: jest.fn(),
-    findUserWithPassword: jest.fn(),
+    findUserWithPasswordByEmail: jest.fn(),
     createUsers: jest.fn(),
     updateUser: jest.fn(),
 };
@@ -69,13 +72,14 @@ describe("Authorization helper methods", () => {
             cb.mockReset();
         });
 
-        it("should create and return a new user if none existed before", async () => {
-            mockUserDAO.findUserWithPassword.mockResolvedValueOnce(undefined);
-            mockUserDAO.createUsers.mockResolvedValueOnce([testUser]);
+        it("if no user with the email exists, should create a new one and return the password-less version", async () => {
+            mockUserDAO.findUserWithPasswordByEmail.mockResolvedValueOnce(undefined);
+            mockUserDAO.createUsers.mockResolvedValueOnce([passwordlessUser]);
+
             await signUpAuthentication(testUser.email, testUser.password!, (mockUserDAO as unknown) as UserDAO, cb);
 
-            expect(mockUserDAO.findUserWithPassword).toBeCalledTimes(1);
-            expect(mockUserDAO.findUserWithPassword).toBeCalledWith({ email: testUser.email });
+            expect(mockUserDAO.findUserWithPasswordByEmail).toBeCalledTimes(1);
+            expect(mockUserDAO.findUserWithPasswordByEmail).toBeCalledWith(testUser.email);
             expect(mockUserDAO.createUsers).toHaveBeenCalledTimes(1);
             expect(mockUserDAO.createUsers).toHaveBeenCalledWith([
                 {
@@ -85,27 +89,27 @@ describe("Authorization helper methods", () => {
                 },
             ]);
             expect(cb).toBeCalledTimes(1);
-            expect(cb).toBeCalledWith(undefined, testUser);
+            expect(cb).toBeCalledWith(undefined, passwordlessUser);
         });
-        it("should update and return an existing user with no password", async () => {
-            const passwordlessUser = new User({ ...testUser });
-            delete passwordlessUser.password;
-            mockUserDAO.findUserWithPassword.mockResolvedValueOnce(passwordlessUser);
-            mockUserDAO.updateUser.mockResolvedValueOnce(testUser);
+        it("if a user exists but has no password set yet, should update the user with the given hashed password and return the password-less version", async () => {
+            mockUserDAO.findUserWithPasswordByEmail.mockResolvedValueOnce(passwordlessUser);
+            mockUserDAO.updateUser.mockResolvedValueOnce(passwordlessUser);
+
             await signUpAuthentication(testUser.email, testUser.password!, (mockUserDAO as unknown) as UserDAO, cb);
 
-            expect(mockUserDAO.findUserWithPassword).toBeCalledTimes(1);
-            expect(mockUserDAO.findUserWithPassword).toBeCalledWith({ email: testUser.email });
+            expect(mockUserDAO.findUserWithPasswordByEmail).toBeCalledTimes(1);
+            expect(mockUserDAO.findUserWithPasswordByEmail).toBeCalledWith(testUser.email);
             expect(mockUserDAO.updateUser).toHaveBeenCalledTimes(1);
             expect(mockUserDAO.updateUser).toHaveBeenCalledWith(testUser.id, {
                 password: expect.any(String),
                 lastLoggedIn: expect.any(Date),
             });
             expect(cb).toBeCalledTimes(1);
-            expect(cb).toBeCalledWith(undefined, testUser);
+            expect(cb).toBeCalledWith(undefined, passwordlessUser);
         });
-        it("should return a ConflictError if the player is already signed up", async () => {
-            mockUserDAO.findUserWithPassword.mockResolvedValueOnce(testUser);
+        it("if a user exists and already h as a password, should return a ConflictError", async () => {
+            mockUserDAO.findUserWithPasswordByEmail.mockResolvedValueOnce(testUser);
+
             await signUpAuthentication(testUser.email, testUser.password!, (mockUserDAO as unknown) as UserDAO, cb);
 
             expect(mockUserDAO.createUsers).toHaveBeenCalledTimes(0);
@@ -121,18 +125,15 @@ describe("Authorization helper methods", () => {
             cb.mockReset();
         });
 
-        it("should return an updated user if the password is matching", async () => {
-            const hashedPassword = await generateHashedPassword(testUser.password!);
-            const testsUserWithHashedPassword = new User({ ...testUser, password: hashedPassword });
-            mockUserDAO.findUserWithPassword.mockResolvedValueOnce(testsUserWithHashedPassword);
-            const passwordlessUser = new User({ ...testUser });
-            delete passwordlessUser.password;
+        it("if signing in with the correct password, should update lastLoggedIn and return a password-less user", async () => {
+            const testsUserWithHashedPassword = new User({ ...testUser, password: await hashedPassword });
+            mockUserDAO.findUserWithPasswordByEmail.mockResolvedValueOnce(testsUserWithHashedPassword);
             mockUserDAO.updateUser.mockResolvedValueOnce(passwordlessUser);
 
             await signInAuthentication(testUser.email, testUser.password!, (mockUserDAO as unknown) as UserDAO, cb);
 
-            expect(mockUserDAO.findUserWithPassword).toBeCalledTimes(1);
-            expect(mockUserDAO.findUserWithPassword).toBeCalledWith({ email: testUser.email });
+            expect(mockUserDAO.findUserWithPasswordByEmail).toBeCalledTimes(1);
+            expect(mockUserDAO.findUserWithPasswordByEmail).toBeCalledWith(testUser.email);
             expect(mockUserDAO.updateUser).toHaveBeenCalledTimes(1);
             expect(mockUserDAO.updateUser).toHaveBeenCalledWith(testUser.id, {
                 lastLoggedIn: expect.any(Date),
@@ -141,11 +142,12 @@ describe("Authorization helper methods", () => {
             expect(cb).toBeCalledWith(undefined, passwordlessUser);
         });
         it("should return an error if the password is not matching", async () => {
-            mockUserDAO.findUserWithPassword.mockResolvedValueOnce(testUser);
+            mockUserDAO.findUserWithPasswordByEmail.mockResolvedValueOnce(new User({...testUser, password: "somethingsomething"}));
+
             await signInAuthentication(testUser.email, testUser.password!, (mockUserDAO as unknown) as UserDAO, cb);
 
-            expect(mockUserDAO.findUserWithPassword).toBeCalledTimes(1);
-            expect(mockUserDAO.findUserWithPassword).toBeCalledWith({ email: testUser.email });
+            expect(mockUserDAO.findUserWithPasswordByEmail).toBeCalledTimes(1);
+            expect(mockUserDAO.findUserWithPasswordByEmail).toBeCalledWith(testUser.email);
             expect(mockUserDAO.updateUser).toHaveBeenCalledTimes(0);
             expect(cb).toBeCalledTimes(1);
             expect(cb).toBeCalledWith(new BadRequestError("Incorrect password"));

--- a/tests/unit/authentication/auth.test.ts
+++ b/tests/unit/authentication/auth.test.ts
@@ -223,7 +223,6 @@ describe("Authorization helper methods", () => {
 
     describe("generateHashedPassword", () => {
         it("should return the hashed string", async () => {
-            const hashedPassword = await generateHashedPassword(testUser.password!);
             expect(testUser.password).not.toEqual(hashedPassword);
         });
     });


### PR DESCRIPTION
I noticed that we sometimes get errors because a user tried to login with an email that had some different casing than what we had stored. (eg: john@ExaMple.com would not be able to  succesfully sign in if what we stored was john@example.com). 

This PR adds a `ILIKE` comparison for the sign-in code path. Also udpated some DAO methods in that code path to be more clearly named.