### PR TITLE
Papercut slack includes trade time

### DIFF
--- a/src/DAO/PlayerDAO.ts
+++ b/src/DAO/PlayerDAO.ts
@@ -6,7 +6,7 @@ import {
     ILike,
     In,
     InsertResult,
-    Repository
+    Repository,
 } from "typeorm";
 import Player from "../models/player";
 

--- a/src/api/routes/AuthController.ts
+++ b/src/api/routes/AuthController.ts
@@ -9,7 +9,7 @@ import {
     Req,
     Res,
     Session,
-    UseBefore
+    UseBefore,
 } from "routing-controllers";
 import { deserializeUser, generateHashedPassword, passwordResetDateIsValid } from "../../authentication/auth";
 import logger from "../../bootstrap/logger";

--- a/src/api/routes/DraftPickController.ts
+++ b/src/api/routes/DraftPickController.ts
@@ -11,7 +11,7 @@ import {
     QueryParam,
     QueryParams,
     Req,
-    UploadedFile
+    UploadedFile,
 } from "routing-controllers";
 import { inspect } from "util";
 import logger from "../../bootstrap/logger";

--- a/src/api/routes/PlayerController.ts
+++ b/src/api/routes/PlayerController.ts
@@ -11,7 +11,7 @@ import {
     QueryParam,
     QueryParams,
     Req,
-    UploadedFile
+    UploadedFile,
 } from "routing-controllers";
 import { inspect } from "util";
 import logger from "../../bootstrap/logger";

--- a/src/api/routes/TeamController.ts
+++ b/src/api/routes/TeamController.ts
@@ -13,7 +13,7 @@ import {
     Put,
     QueryParam,
     QueryParams,
-    Req
+    Req,
 } from "routing-controllers";
 import { inspect } from "util";
 import logger from "../../bootstrap/logger";

--- a/src/api/routes/TradeController.ts
+++ b/src/api/routes/TradeController.ts
@@ -13,7 +13,7 @@ import {
     Put,
     QueryParam,
     Req,
-    UnauthorizedError
+    UnauthorizedError,
 } from "routing-controllers";
 import { inspect } from "util";
 import logger from "../../bootstrap/logger";

--- a/src/api/routes/UserController.ts
+++ b/src/api/routes/UserController.ts
@@ -10,7 +10,7 @@ import {
     Post,
     Put,
     QueryParam,
-    Req
+    Req,
 } from "routing-controllers";
 import { inspect } from "util";
 import logger from "../../bootstrap/logger";

--- a/src/models/player.ts
+++ b/src/models/player.ts
@@ -6,7 +6,7 @@ import {
     ESPN_ELIGIBLE_POSITION_MAPPING,
     ESPN_NON_POSITIONAL_NON_VALID_SLOTS,
     ESPN_POSITION_MAPPING,
-    espnMajorLeagueTeamFromId
+    espnMajorLeagueTeamFromId,
 } from "../espn/espnConstants";
 
 /* eslint-disable @typescript-eslint/naming-convention */

--- a/src/slack/tradeFormatter.ts
+++ b/src/slack/tradeFormatter.ts
@@ -130,9 +130,26 @@ ${ordinal(pick!.round)} round ${this.getPickTypeString(pick!.type)} pick${
                 .join(", ");
         }
 
+        function tradeUpholdTime() {
+            const now = new Date();
+            let upholdTime = new Date();
+            const addDaysToDate = (dateToModify, dateToAddTo, days) => new Date(dateToModify.setDate(dateToAddTo.getDate() + days));
+
+            if (now.getHours() < 23) {
+                // It is before 11PM, so trade will be upheld by tomorrow at 11pm.
+                upholdTime = addDaysToDate(upholdTime, now, 1);
+            } else {
+                // It is after 11PM, so trade won't be upheld until the day-after-tomorrow at 11pm.
+                upholdTime = addDaysToDate(upholdTime, now, 2);
+            }
+            upholdTime.setHours(23, 0, 0, 0);
+            return upholdTime.toLocaleString("en-CA");
+        }
+
         return `*${new Date().toDateString()}* \
 | Trade requested by ${getSlackUsernamesForOwners(trade.creator!.owners!)} \
-- Trading with: ${getSlackUsernamesForOwners(trade.recipients.flatMap(r => r.owners!))}`;
+- Trading with: ${getSlackUsernamesForOwners(trade.recipients.flatMap(r => r.owners!))} \
+| Trade will be reviewed by: ${tradeUpholdTime()} (Eastern)`;
     },
 
     getNotificationText: (trade: Trade) => {

--- a/src/slack/tradeFormatter.ts
+++ b/src/slack/tradeFormatter.ts
@@ -133,7 +133,8 @@ ${ordinal(pick!.round)} round ${this.getPickTypeString(pick!.type)} pick${
         function tradeUpholdTime() {
             const now = new Date();
             let upholdTime = new Date();
-            const addDaysToDate = (dateToModify, dateToAddTo, days) => new Date(dateToModify.setDate(dateToAddTo.getDate() + days));
+            const addDaysToDate = (dateToModify: Date, dateToAddTo: Date, days: number) =>
+                new Date(dateToModify.setDate(dateToAddTo.getDate() + days));
 
             if (now.getHours() < 23) {
                 // It is before 11PM, so trade will be upheld by tomorrow at 11pm.

--- a/tests/integration/AuthRoutes.test.ts
+++ b/tests/integration/AuthRoutes.test.ts
@@ -8,7 +8,7 @@ import startServer from "../../src/bootstrap/app";
 import { clearDb, makeLoggedInRequest, makePostRequest } from "./helpers";
 import { getConnection } from "typeorm";
 import { generateHashedPassword } from "../../src/authentication/auth";
-import { advanceBy } from "jest-date-mock";
+import { advanceBy, clear } from "jest-date-mock";
 
 let app: Server;
 let userDAO: UserDAO;
@@ -168,6 +168,7 @@ describe("Auth API endpoints", () => {
             const hashedPass = await generateHashedPassword(testUser.password);
             return await userDAO.createUsers([{ email: testUser.email, password: hashedPass }]);
         });
+        afterEach(() => clear());
 
         it("should successfully update the user with the hashed password", async () => {
             const { id } = (await userDAO.findUser({ email: testUser.email }, true)) as User;

--- a/tests/integration/DraftPickRoutes.test.ts
+++ b/tests/integration/DraftPickRoutes.test.ts
@@ -20,7 +20,7 @@ import {
     makePutRequest,
     ownerLoggedIn,
     setupOwnerAndAdminUsers,
-    stringifyQuery
+    stringifyQuery,
 } from "./helpers";
 import { v4 as uuid } from "uuid";
 import startServer from "../../src/bootstrap/app";

--- a/tests/integration/PlayerRoutes.test.ts
+++ b/tests/integration/PlayerRoutes.test.ts
@@ -22,7 +22,7 @@ import {
     makePutRequest,
     ownerLoggedIn,
     setupOwnerAndAdminUsers,
-    stringifyQuery
+    stringifyQuery,
 } from "./helpers";
 import { v4 as uuid } from "uuid";
 import startServer from "../../src/bootstrap/app";

--- a/tests/integration/SettingsRoutes.test.ts
+++ b/tests/integration/SettingsRoutes.test.ts
@@ -13,7 +13,7 @@ import {
     makeGetRequest,
     makePostRequest,
     ownerLoggedIn,
-    setupOwnerAndAdminUsers
+    setupOwnerAndAdminUsers,
 } from "./helpers";
 import startServer from "../../src/bootstrap/app";
 import { getConnection } from "typeorm";

--- a/tests/integration/TeamRoutes.test.ts
+++ b/tests/integration/TeamRoutes.test.ts
@@ -20,7 +20,7 @@ import {
     makePutRequest,
     ownerLoggedIn,
     setupOwnerAndAdminUsers,
-    stringifyQuery
+    stringifyQuery,
 } from "./helpers";
 import startServer from "../../src/bootstrap/app";
 import User from "../../src/models/user";

--- a/tests/integration/TradeRoutes.test.ts
+++ b/tests/integration/TradeRoutes.test.ts
@@ -22,7 +22,7 @@ import {
     makePostRequest,
     makePutRequest,
     ownerLoggedIn,
-    setupOwnerAndAdminUsers
+    setupOwnerAndAdminUsers,
 } from "./helpers";
 import { v4 as uuid } from "uuid";
 import * as TradeTracker from "../../src/csv/TradeTracker";

--- a/tests/integration/UserRoutes.test.ts
+++ b/tests/integration/UserRoutes.test.ts
@@ -17,7 +17,7 @@ import {
     makePutRequest,
     ownerLoggedIn,
     setupOwnerAndAdminUsers,
-    stringifyQuery
+    stringifyQuery,
 } from "./helpers";
 import { v4 as uuid } from "uuid";
 import { getConnection } from "typeorm";

--- a/tests/unit/authentication/auth.test.ts
+++ b/tests/unit/authentication/auth.test.ts
@@ -9,7 +9,7 @@ import {
     passwordResetDateIsValid,
     serializeUser,
     signInAuthentication,
-    signUpAuthentication
+    signUpAuthentication,
 } from "../../../src/authentication/auth";
 import UserDAO from "../../../src/DAO/UserDAO";
 import User, { Role } from "../../../src/models/user";

--- a/tests/unit/slack/tradeFormatter.test.ts
+++ b/tests/unit/slack/tradeFormatter.test.ts
@@ -7,7 +7,7 @@ import DraftPickDAO from "../../../src/DAO/DraftPickDAO";
 import { TeamFactory } from "../../factories/TeamFactory";
 import PlayerDAO from "../../../src/DAO/PlayerDAO";
 import { LeagueLevel } from "../../../src/models/draftPick";
-import {advanceTo, clear} from "jest-date-mock";
+import { advanceTo, clear } from "jest-date-mock";
 
 beforeAll(() => {
     logger.debug("~~~~~~SLACK TRADE FORMATTER TESTS BEGIN~~~~~~");


### PR DESCRIPTION
From request from Adam:

- all trades are subject to a review period of at least 24 hours
- review periods can only end at 11pm
- so a trade completed today at 1pm would be approved tomorrow at 11pm
- a trade completed at 11:01pm tonight would be approved 2 days from now at 11pm
- since when tomorrow at 11pm rolls around 24 hours would not have elapsed
- would be good for the slack message to include when the trade should be upheld