### PR TITLE
BUGFIX - trade upheld message

### DIFF
--- a/src/slack/tradeFormatter.ts
+++ b/src/slack/tradeFormatter.ts
@@ -131,7 +131,8 @@ ${ordinal(pick!.round)} round ${this.getPickTypeString(pick!.type)} pick${
         }
 
         function tradeUpholdTime() {
-            const now = new Date();
+            const nowUTC = new Date();
+            const now = new Date(nowUTC.toLocaleString("en-US", { timeZone: "America/Toronto" }));
             let upholdTime = new Date();
             const addDaysToDate = (dateToModify: Date, dateToAddTo: Date, days: number) =>
                 new Date(dateToModify.setDate(dateToAddTo.getDate() + days));
@@ -150,7 +151,7 @@ ${ordinal(pick!.round)} round ${this.getPickTypeString(pick!.type)} pick${
         return `*${new Date().toDateString()}* \
 | Trade requested by ${getSlackUsernamesForOwners(trade.creator!.owners!)} \
 - Trading with: ${getSlackUsernamesForOwners(trade.recipients.flatMap(r => r.owners!))} \
-| Trade will be reviewed by: ${tradeUpholdTime()} (Eastern)`;
+| Trade will be upheld after: ${tradeUpholdTime()} (Eastern)`;
     },
 
     getNotificationText: (trade: Trade) => {

--- a/tests/unit/slack/tradeFormatter.test.ts
+++ b/tests/unit/slack/tradeFormatter.test.ts
@@ -73,7 +73,7 @@ describe("Trade Formatter methods", () => {
         expect(text).toMatch(`<@${trade.creator!.owners![0].slackUsername}>`);
         expect(text).toMatch(`<@${trade.recipients[0].owners![0].slackUsername}>`);
         expect(text).toMatch("Trading with: ");
-        expect(text).toMatch("Trade will be reviewed by:");
+        expect(text).toMatch("Trade will be upheld after:");
     });
     it("getSubtitleText/1 should correctly format the 'trade upheld by' part", () => {
         // Note to self: JS Date uses 0-indexed month value.


### PR DESCRIPTION
server node timezone is UTC, so tradeFormatter was not giving the right result; don't want to bring in date lib if not needed so using conversion to string as a workaround