### PR TITLE
BUGFIX- slack subtitle timezone formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "cors": "^2.8.5",
         "custom-fonts-in-emails": "^4.0.2",
         "date-fns": "^2.19.0",
+        "date-fns-tz": "^1.3.6",
         "dotenv": "^6.2.0",
         "email-templates": "^8.0",
         "express": "^4.17.2",
@@ -4264,6 +4265,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.6.tgz",
+      "integrity": "sha512-C8q7mErvG4INw1ZwAFmPlGjEo5Sv4udjKVbTc03zpP9cu6cp5AemFzKhz0V68LGcWEtX5mJudzzg3G04emIxLA==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/dayjs": {
@@ -16485,6 +16494,12 @@
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
       "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+    },
+    "date-fns-tz": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.6.tgz",
+      "integrity": "sha512-C8q7mErvG4INw1ZwAFmPlGjEo5Sv4udjKVbTc03zpP9cu6cp5AemFzKhz0V68LGcWEtX5mJudzzg3G04emIxLA==",
+      "requires": {}
     },
     "dayjs": {
       "version": "1.10.7",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cors": "^2.8.5",
     "custom-fonts-in-emails": "^4.0.2",
     "date-fns": "^2.19.0",
+    "date-fns-tz": "^1.3.6",
     "dotenv": "^6.2.0",
     "email-templates": "^8.0",
     "express": "^4.17.2",

--- a/tests/unit/slack/tradeFormatter.test.ts
+++ b/tests/unit/slack/tradeFormatter.test.ts
@@ -67,7 +67,11 @@ describe("Trade Formatter methods", () => {
         expect(text).toMatch(`${trade.creator!.name} & ${trade.recipients[0]!.name}`);
     });
     it("getSubtitleText/1 should format the subtitle with the correct date and slack tags", () => {
+        // Note to self: JS Date uses 0-indexed month value.
+        // mock date at 11am
+        advanceTo(new Date(2018, 5, 27, 11, 0, 0));
         const text = TradeFormatter.getSubtitleText(trade);
+        expect(text).toMatch("*Wed Jun 27 2018*");
         expect(text).toMatch("Trade requested by");
         expect(text).toMatch("Trading with: ");
         expect(text).toMatch(`<@${trade.creator!.owners![0].slackUsername}>`);
@@ -81,19 +85,19 @@ describe("Trade Formatter methods", () => {
         advanceTo(new Date(2018, 5, 27, 11, 0, 0));
         const textBefore11 = TradeFormatter.getSubtitleText(trade);
         // trade will be upheld by next day at 11pm
-        expect(textBefore11).toMatch("2018-06-28, 11:00:00 p.m. (Eastern)");
+        expect(textBefore11).toMatch("Thu Jun 28 2018, 11:00 p.m. EDT");
 
         // mock date at 11:01pm
         advanceTo(new Date(2018, 5, 27, 23, 1, 0));
         const textAfter11 = TradeFormatter.getSubtitleText(trade);
         // trade will be upheld the day after next at 11pm
-        expect(textAfter11).toMatch("2018-06-29, 11:00:00 p.m. (Eastern)");
+        expect(textAfter11).toMatch("Fri Jun 29 2018, 11:00 p.m. EDT");
 
         // mock date at 11:00pm on the dot
         advanceTo(new Date(2018, 5, 27, 23, 0, 0, 0));
         const textAt11 = TradeFormatter.getSubtitleText(trade);
         // trade will be upheld the day after next at 11pm
-        expect(textAt11).toMatch("2018-06-29, 11:00:00 p.m. (Eastern)");
+        expect(textAt11).toMatch("Fri Jun 29 2018, 11:00 p.m. EDT");
     });
     it("prepPickText/3 should format a bullet point list of picks", async () => {
         const text = await TradeFormatter.prepPickText(true, TradeItem.filterPicks(trade.tradeItems), mockPickDao);


### PR DESCRIPTION
I realized that the server uses UTC. Also realized that we already use date-fns so instead of trying to fiddle with the finicky JS built-ins just relied on that (and pulled in date-fns-tz) to handle timezones and handle formatting