### PR TITLE
Add trades by status

### DIFF
--- a/src/DAO/TradeDAO.ts
+++ b/src/DAO/TradeDAO.ts
@@ -1,4 +1,4 @@
-import { DeleteResult, FindManyOptions, getConnection, Repository } from "typeorm";
+import { DeleteResult, FindManyOptions, getConnection, In, Repository } from "typeorm";
 import Trade, { TradeStatus } from "../models/trade";
 import TradeItem, { TradeItemType } from "../models/tradeItem";
 import TradeParticipant from "../models/tradeParticipant";
@@ -36,12 +36,24 @@ export default class TradeDAO {
         return await this.tradeDb.find(options);
     }
 
-    public async returnHydratedTrades(pageSize = 25, pageNumber = 1): Promise<HydratedTrade[]> {
+    public async returnHydratedTrades(
+        statuses?: TradeStatus[],
+        pageSize = 25,
+        pageNumber = 1
+    ): Promise<HydratedTrade[]> {
         const pagingOptions = {
             skip: (pageNumber - 1) * pageSize,
             take: pageSize,
         };
-        return await this.hydratedTradeDb.find({ order: { dateCreated: "DESC" }, ...pagingOptions });
+        if (statuses) {
+            return await this.hydratedTradeDb.find({
+                where: { tradeStatus: In(statuses) },
+                order: { dateCreated: "DESC" },
+                ...pagingOptions,
+            });
+        } else {
+            return await this.hydratedTradeDb.find({ order: { dateCreated: "DESC" }, ...pagingOptions });
+        }
     }
 
     public async getTradeById(id: string): Promise<Trade> {

--- a/src/DAO/TradeDAO.ts
+++ b/src/DAO/TradeDAO.ts
@@ -42,7 +42,7 @@ export default class TradeDAO {
         includeTeam?: string,
         pageSize = 25,
         pageNumber = 1
-    ): Promise<HydratedTrade[]> {
+    ): Promise<[HydratedTrade[], number]> {
         let where: FindConditions<HydratedTrade>[] | FindConditions<HydratedTrade> | undefined;
 
         if (statuses && includeTeam) {
@@ -70,12 +70,12 @@ export default class TradeDAO {
         };
 
         return await (whereClause
-            ? this.hydratedTradeDb.find({
+            ? this.hydratedTradeDb.findAndCount({
                 order: { dateCreated: "DESC" },
                 ...pagingOptions,
                   where,
               })
-            : this.hydratedTradeDb.find({ order: { dateCreated: "DESC" }, ...pagingOptions }));
+            : this.hydratedTradeDb.findAndCount({ order: { dateCreated: "DESC" }, ...pagingOptions }));
     }
 
     public async getTradeById(id: string): Promise<Trade> {

--- a/src/DAO/TradeDAO.ts
+++ b/src/DAO/TradeDAO.ts
@@ -1,4 +1,4 @@
-import { DeleteResult, FindManyOptions, getConnection, In, Repository } from "typeorm";
+import {DeleteResult, FindManyOptions, getConnection, In, Raw, Repository} from "typeorm";
 import Trade, { TradeStatus } from "../models/trade";
 import TradeItem, { TradeItemType } from "../models/tradeItem";
 import TradeParticipant from "../models/tradeParticipant";
@@ -6,6 +6,7 @@ import { BadRequestError } from "routing-controllers";
 import PlayerDAO from "./PlayerDAO";
 import DraftPickDAO from "./DraftPickDAO";
 import { HydratedTrade } from "../models/views/hydratedTrades";
+import { FindConditions } from "typeorm/find-options/FindConditions";
 
 interface TradeDeleteResult extends DeleteResult {
     raw: Trade[];
@@ -38,22 +39,43 @@ export default class TradeDAO {
 
     public async returnHydratedTrades(
         statuses?: TradeStatus[],
+        includeTeam?: string,
         pageSize = 25,
         pageNumber = 1
     ): Promise<HydratedTrade[]> {
+        let where: FindConditions<HydratedTrade>[] | FindConditions<HydratedTrade> | undefined;
+
+        if (statuses && includeTeam) {
+            where = [
+                { tradeCreator: includeTeam, tradeStatus: In(statuses) },
+                {
+                    tradeRecipients: Raw(tp => ':teamName = ANY("tradeRecipients")', { teamName: includeTeam }),
+                    tradeStatus: In(statuses),
+                },
+            ];
+        } else if (statuses) {
+            where = { tradeStatus: In(statuses) };
+        } else if (includeTeam) {
+            where = [
+                { tradeCreator: includeTeam },
+                { tradeRecipients: Raw(tp => ':teamName = ANY("tradeRecipients")', { teamName: includeTeam }) },
+            ];
+        }
+
+        const whereClause = where ? { where } : undefined;
+
         const pagingOptions = {
             skip: (pageNumber - 1) * pageSize,
             take: pageSize,
         };
-        if (statuses) {
-            return await this.hydratedTradeDb.find({
-                where: { tradeStatus: In(statuses) },
+
+        return await (whereClause
+            ? this.hydratedTradeDb.find({
                 order: { dateCreated: "DESC" },
                 ...pagingOptions,
-            });
-        } else {
-            return await this.hydratedTradeDb.find({ order: { dateCreated: "DESC" }, ...pagingOptions });
-        }
+                  where,
+              })
+            : this.hydratedTradeDb.find({ order: { dateCreated: "DESC" }, ...pagingOptions }));
     }
 
     public async getTradeById(id: string): Promise<Trade> {

--- a/src/DAO/TradeDAO.ts
+++ b/src/DAO/TradeDAO.ts
@@ -1,4 +1,4 @@
-import {DeleteResult, FindManyOptions, getConnection, In, Raw, Repository} from "typeorm";
+import { DeleteResult, FindManyOptions, getConnection, In, Raw, Repository } from "typeorm";
 import Trade, { TradeStatus } from "../models/trade";
 import TradeItem, { TradeItemType } from "../models/tradeItem";
 import TradeParticipant from "../models/tradeParticipant";
@@ -71,8 +71,8 @@ export default class TradeDAO {
 
         return await (whereClause
             ? this.hydratedTradeDb.findAndCount({
-                order: { dateCreated: "DESC" },
-                ...pagingOptions,
+                  order: { dateCreated: "DESC" },
+                  ...pagingOptions,
                   where,
               })
             : this.hydratedTradeDb.findAndCount({ order: { dateCreated: "DESC" }, ...pagingOptions }));

--- a/src/api/routes/TradeController.ts
+++ b/src/api/routes/TradeController.ts
@@ -147,13 +147,13 @@ export default class TradeController {
         @QueryParam("pageSize") pageSize?: number,
         @QueryParam("pageNumber") pageNumber?: number,
         @QueryParam("statuses") statuses?: TradeStatus[],
+        @QueryParam("includesTeam") includeTeam?: string,
         @Req() request?: Request
     ): Promise<Trade[] | HydratedTrade[]> {
-        logger.debug(`get all trades endpoint; ${inspect({ hydrated, pageSize, pageNumber, statuses })}`);
-        rollbar.info("getAllTrades", { hydrated, pageSize, pageNumber }, request);
+        logger.debug(`get all trades endpoint; ${inspect({ hydrated, pageSize, pageNumber, statuses, includeTeam })}`);
+        rollbar.info("getAllTrades", { hydrated, pageSize, pageNumber, statuses, includeTeam }, request);
         if (hydrated) {
-            // return await Promise.all(trades.map(t => this.dao.hydrateTrade(t)));
-            const hydratedTrades = await this.dao.returnHydratedTrades(statuses, pageSize, pageNumber);
+            const hydratedTrades = await this.dao.returnHydratedTrades(statuses, includeTeam, pageSize, pageNumber);
             logger.debug(`got ${hydratedTrades.length} hydrated trades`);
             return hydratedTrades;
         } else {

--- a/src/api/routes/TradeController.ts
+++ b/src/api/routes/TradeController.ts
@@ -13,7 +13,7 @@ import {
     Put,
     QueryParam,
     Req,
-    UnauthorizedError
+    UnauthorizedError,
 } from "routing-controllers";
 import { inspect } from "util";
 import logger from "../../bootstrap/logger";
@@ -153,9 +153,14 @@ export default class TradeController {
         logger.debug(`get all trades endpoint; ${inspect({ hydrated, pageSize, pageNumber, statuses, includeTeam })}`);
         rollbar.info("getAllTrades", { hydrated, pageSize, pageNumber, statuses, includeTeam }, request);
         if (hydrated) {
-            const [hydratedTrades, total] = await this.dao.returnHydratedTrades(statuses, includeTeam, pageSize, pageNumber);
+            const [hydratedTrades, total] = await this.dao.returnHydratedTrades(
+                statuses,
+                includeTeam,
+                pageSize,
+                pageNumber
+            );
             logger.debug(`got ${hydratedTrades.length} hydrated trades`);
-            return {trades: hydratedTrades, total};
+            return { trades: hydratedTrades, total };
         } else {
             const trades = await this.dao.getAllTrades();
             logger.debug(`got ${trades.length} trades`);

--- a/src/api/routes/TradeController.ts
+++ b/src/api/routes/TradeController.ts
@@ -136,13 +136,9 @@ async function acceptTradeIfValid(dao: TradeDAO, acceptingUser: User, trade: Tra
 @JsonController("/trades")
 export default class TradeController {
     private readonly dao: TradeDAO;
-    private emailPublisher: EmailPublisher;
-    private slackPublisher: SlackPublisher;
 
-    constructor(dao?: TradeDAO, publisher?: EmailPublisher, slackPublisher?: SlackPublisher) {
+    constructor(dao?: TradeDAO) {
         this.dao = dao || new TradeDAO();
-        this.emailPublisher = publisher || EmailPublisher.getInstance();
-        this.slackPublisher = slackPublisher || SlackPublisher.getInstance();
     }
 
     @Get("/")
@@ -150,13 +146,14 @@ export default class TradeController {
         @QueryParam("hydrated") hydrated?: boolean,
         @QueryParam("pageSize") pageSize?: number,
         @QueryParam("pageNumber") pageNumber?: number,
+        @QueryParam("statuses") statuses?: TradeStatus[],
         @Req() request?: Request
     ): Promise<Trade[] | HydratedTrade[]> {
-        logger.debug(`get all trades endpoint; ${inspect({ hydrated, pageSize, pageNumber })}`);
+        logger.debug(`get all trades endpoint; ${inspect({ hydrated, pageSize, pageNumber, statuses })}`);
         rollbar.info("getAllTrades", { hydrated, pageSize, pageNumber }, request);
         if (hydrated) {
             // return await Promise.all(trades.map(t => this.dao.hydrateTrade(t)));
-            const hydratedTrades = await this.dao.returnHydratedTrades(pageSize, pageNumber);
+            const hydratedTrades = await this.dao.returnHydratedTrades(statuses, pageSize, pageNumber);
             logger.debug(`got ${hydratedTrades.length} hydrated trades`);
             return hydratedTrades;
         } else {

--- a/src/api/routes/TradeController.ts
+++ b/src/api/routes/TradeController.ts
@@ -13,7 +13,7 @@ import {
     Put,
     QueryParam,
     Req,
-    UnauthorizedError,
+    UnauthorizedError
 } from "routing-controllers";
 import { inspect } from "util";
 import logger from "../../bootstrap/logger";
@@ -149,13 +149,13 @@ export default class TradeController {
         @QueryParam("statuses") statuses?: TradeStatus[],
         @QueryParam("includesTeam") includeTeam?: string,
         @Req() request?: Request
-    ): Promise<Trade[] | HydratedTrade[]> {
+    ): Promise<Trade[] | { trades: HydratedTrade[]; total: number }> {
         logger.debug(`get all trades endpoint; ${inspect({ hydrated, pageSize, pageNumber, statuses, includeTeam })}`);
         rollbar.info("getAllTrades", { hydrated, pageSize, pageNumber, statuses, includeTeam }, request);
         if (hydrated) {
-            const hydratedTrades = await this.dao.returnHydratedTrades(statuses, includeTeam, pageSize, pageNumber);
+            const [hydratedTrades, total] = await this.dao.returnHydratedTrades(statuses, includeTeam, pageSize, pageNumber);
             logger.debug(`got ${hydratedTrades.length} hydrated trades`);
-            return hydratedTrades;
+            return {trades: hydratedTrades, total};
         } else {
             const trades = await this.dao.getAllTrades();
             logger.debug(`got ${trades.length} trades`);

--- a/src/db/seed/createRandomTrade.ts
+++ b/src/db/seed/createRandomTrade.ts
@@ -16,8 +16,7 @@ import TradeDAO from "../../DAO/TradeDAO";
 import logger from "../../bootstrap/logger";
 import { inspect } from "util";
 import Team from "../../models/team";
-import {randomUUID} from "crypto";
-
+import { randomUUID } from "crypto";
 
 async function run() {
     const args = process.argv.slice(2);

--- a/src/db/seed/createRandomTrade.ts
+++ b/src/db/seed/createRandomTrade.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import { config as dotenvConfig } from "dotenv";
 import { resolve as resolvePath } from "path";
+dotenvConfig({ path: resolvePath(__dirname, "../../../.env") });
 import initializeDb from "../../bootstrap/db";
 import TradeParticipant, { TradeParticipantType } from "../../models/tradeParticipant";
 import TeamDAO from "../../DAO/TeamDAO";
@@ -14,25 +15,26 @@ import Trade from "../../models/trade";
 import TradeDAO from "../../DAO/TradeDAO";
 import logger from "../../bootstrap/logger";
 import { inspect } from "util";
+import Team from "../../models/team";
+import {randomUUID} from "crypto";
 
-dotenvConfig({ path: resolvePath(__dirname, "../../../.env") });
 
 async function run() {
     const args = process.argv.slice(2);
-    const numTeams = parseInt(args[0], 10);
-    const numMajors = parseInt(args[1], 10);
-    const numMinors = parseInt(args[2], 10);
-    const numPicks = parseInt(args[3], 10);
+    const numTeams = args[0] ? parseInt(args[0], 10) : 2;
+    const numMajors = args[1] ? parseInt(args[1], 10) : 1;
+    const numMinors = args[2] ? parseInt(args[2], 10) : 1;
+    const numPicks = args[3] ? parseInt(args[3], 10) : 1;
     await initializeDb(process.env.DB_LOGS === "true");
 
     const teamDao = new TeamDAO();
     const playerDao = new PlayerDAO();
     const pickDao = new DraftPickDAO();
     const tradeDao = new TradeDAO();
-    const allTeams = shuffle(await teamDao.getAllTeams());
+    const allTeams = shuffle<Team>(await teamDao.getAllTeams());
     const allMajorPlayers = await playerDao.findPlayers({ league: PlayerLeagueType.MAJOR });
     const allMinorPlayers = await playerDao.findPlayers({ league: PlayerLeagueType.MINOR });
-    const allPicks = await pickDao.getAllPicks();
+    const allPicks = await pickDao.getAllPicks(true);
 
     const creator = new TradeParticipant({
         id: uuid(),
@@ -92,10 +94,14 @@ async function run() {
 
     const items = [...tradedMajors, ...tradedMinors, ...tradedPicks];
 
-    const trade = new Trade({ tradeParticipants: participants, tradeItems: items });
+    const trade = new Trade({ id: randomUUID(), tradeParticipants: participants, tradeItems: items });
     return await tradeDao.createTrade(trade);
 }
 
+/**
+ * Call with: DB_LOGS=<optional_boolean> ts-node src/db/seed/createRandomTrade.ts <num_teams_involved:2> <num_majors_involved:1> <num_minors_involved:1> <num_picks_involved:1>
+ *     - all args are optional and have defaults
+ */
 run()
     .then(trade => {
         logger.info(`${trade.id}`);

--- a/src/db/seed/helpers/teamCreator.ts
+++ b/src/db/seed/helpers/teamCreator.ts
@@ -4,7 +4,7 @@ import UserDAO from "../../../DAO/UserDAO";
 import TeamDAO from "../../../DAO/TeamDAO";
 import User from "../../../models/user";
 import { sample } from "lodash";
-import {randomUUID} from "crypto";
+import { randomUUID } from "crypto";
 
 let dao: TeamDAO | null;
 let allUsers: User[] | null;

--- a/src/db/seed/helpers/teamCreator.ts
+++ b/src/db/seed/helpers/teamCreator.ts
@@ -4,6 +4,7 @@ import UserDAO from "../../../DAO/UserDAO";
 import TeamDAO from "../../../DAO/TeamDAO";
 import User from "../../../models/user";
 import { sample } from "lodash";
+import {randomUUID} from "crypto";
 
 let dao: TeamDAO | null;
 let allUsers: User[] | null;
@@ -20,7 +21,7 @@ async function init() {
 export function createGenericTeam() {
     const name = `Team ${random.word()}`;
     const status = TeamStatus.ACTIVE;
-    return new Team({ name, status });
+    return new Team({ id: randomUUID(), name, status });
 }
 
 export function createInactiveTeam() {

--- a/src/db/seed/helpers/userCreator.ts
+++ b/src/db/seed/helpers/userCreator.ts
@@ -1,6 +1,7 @@
 import { internet, name as fakeName } from "faker";
 import UserDAO from "../../../DAO/UserDAO";
 import User, { Role, UserStatus } from "../../../models/user";
+import { randomUUID } from "crypto";
 
 let dao: UserDAO | null;
 
@@ -15,7 +16,7 @@ export function createGenericUser() {
     const slackUsername = internet.userName();
     const email = internet.email();
     const displayName = fakeName.findName();
-    return new User({ slackUsername, email, displayName, role: Role.OWNER });
+    return new User({id: randomUUID(), slackUsername, email, displayName, role: Role.OWNER});
 }
 
 export function createAdminUser() {

--- a/src/db/seed/helpers/userCreator.ts
+++ b/src/db/seed/helpers/userCreator.ts
@@ -16,7 +16,7 @@ export function createGenericUser() {
     const slackUsername = internet.userName();
     const email = internet.email();
     const displayName = fakeName.findName();
-    return new User({id: randomUUID(), slackUsername, email, displayName, role: Role.OWNER});
+    return new User({ id: randomUUID(), slackUsername, email, displayName, role: Role.OWNER });
 }
 
 export function createAdminUser() {

--- a/src/db/seed/seedTeam.ts
+++ b/src/db/seed/seedTeam.ts
@@ -1,4 +1,7 @@
 /* eslint-disable */
+import { config as dotenvConfig } from "dotenv";
+import { resolve as resolvePath } from "path";
+dotenvConfig({ path: resolvePath(__dirname, "../../../.env") });
 import initializeDb from "../../bootstrap/db";
 import { createGenericTeam, createInactiveTeam, saveOwners, saveTeam } from "./helpers/teamCreator";
 import Team from "../../models/team";
@@ -67,6 +70,12 @@ function getTeamObj(args: any[]) {
     }
 }
 
+/**
+ * Call with: DB_LOGS=<optional_boolean> ts-node src/db/seed/seedTeam.ts <inactive|owned|null> <owner_user_id> to create a disabled-status team owned team or an active-status team
+ *   - if owned was passed, script will check second argument for a user id that's in the db and set the created team's owner to that user (only accepts one currently)
+ * Call with: DB_LOGS=<optional_boolean> ts-node src/db/seed/seedUser.ts custom <team_obj_json> to create a team with the passed in json definition
+ *   - if the json argument has an `owners` field, it will set the owners of the newly created team to that (can be an array of more than one owner)
+ */
 run()
     .then(user => {
         logger.info(inspect(user));

--- a/src/db/seed/seedUser.ts
+++ b/src/db/seed/seedUser.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import { config as dotenvConfig } from "dotenv";
 import { resolve as resolvePath } from "path";
+dotenvConfig({ path: resolvePath(__dirname, "../../../.env") });
 import initializeDb from "../../bootstrap/db";
 import { registerUser } from "./helpers/authHelper";
 import { createAdminUser, createGenericUser, createInactiveUser, saveUser } from "./helpers/userCreator";
@@ -8,7 +9,6 @@ import User from "../../models/user";
 import logger from "../../bootstrap/logger";
 import { inspect } from "util";
 
-dotenvConfig({ path: resolvePath(__dirname, "../../../.env") });
 
 async function run() {
     const args = process.argv.slice(2);
@@ -45,6 +45,10 @@ function getUserObj(args: any[]) {
     }
 }
 
+/**
+ * Call with: DB_LOGS=<optional_boolean> ts-node src/db/seed/seedUser.ts <admin|inactive|null> (to create an admin-role user, inactive-status user, or owner-role user)
+ * Call with: DB_LOGS=<optional_boolean> ts-node src/db/seed/seedUser.ts custom <user_obj_json> to create a user with the specific shape passed in
+ */
 run()
     .then(user => {
         logger.info(inspect(user));

--- a/src/db/seed/seedUser.ts
+++ b/src/db/seed/seedUser.ts
@@ -9,7 +9,6 @@ import User from "../../models/user";
 import logger from "../../bootstrap/logger";
 import { inspect } from "util";
 
-
 async function run() {
     const args = process.argv.slice(2);
     await initializeDb(process.env.DB_LOGS === "true");

--- a/src/scheduled_jobs/publisher.ts
+++ b/src/scheduled_jobs/publisher.ts
@@ -18,13 +18,13 @@ export class Publisher {
         return this.queue!.clean(100, "wait");
     }
 
-    public async closeQueue(): Promise<void> {
-        return this.queue!.close()
+    public async closeQueue(wait = false): Promise<void> {
+        return this.queue!.close(wait)
             .then(() => {
                 logger.info(`Closing the queue. ${this.queue!.name}`);
             })
             .catch(() => {
-                logger.error(`Erorr closing queue. ${this.queue!.name}`);
+                logger.error(`Error closing queue. ${this.queue!.name}`);
             });
     }
 }

--- a/tests/factories/Counter.ts
+++ b/tests/factories/Counter.ts
@@ -1,0 +1,7 @@
+export const espnIdCounter = (function () {
+    let counter = 1;
+
+    return function () {
+        return (counter += 1);
+    };
+})();

--- a/tests/factories/TeamFactory.ts
+++ b/tests/factories/TeamFactory.ts
@@ -7,7 +7,7 @@ export class TeamFactory {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public static NAME = "Squirtle Squad";
 
-    public static getTeamObject(name = TeamFactory.NAME, espnId = 1, rest = {}) {
+    public static getTeamObject(name = TeamFactory.NAME, espnId = espnIdCounter(), rest = {}) {
         return { id: uuid(), name, espnId, ...rest };
     }
 

--- a/tests/factories/TeamFactory.ts
+++ b/tests/factories/TeamFactory.ts
@@ -1,6 +1,7 @@
 import { name as fakeName } from "faker";
 import Team from "../../src/models/team";
 import { v4 as uuid } from "uuid";
+import { espnIdCounter } from "./Counter";
 
 export class TeamFactory {
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -10,7 +11,7 @@ export class TeamFactory {
         return { id: uuid(), name, espnId, ...rest };
     }
 
-    public static getTeam(name = TeamFactory.NAME, espnId = 1, rest = {}) {
+    public static getTeam(name = TeamFactory.NAME, espnId = espnIdCounter(), rest = {}) {
         return new Team(TeamFactory.getTeamObject(name, espnId, rest));
     }
 

--- a/tests/factories/TradeFactory.ts
+++ b/tests/factories/TradeFactory.ts
@@ -7,6 +7,7 @@ import { PlayerFactory } from "./PlayerFactory";
 import { TeamFactory } from "./TeamFactory";
 import { v4 as uuid } from "uuid";
 import Team from "../../src/models/team";
+import { espnIdCounter } from "./Counter";
 
 export class TradeFactory {
     public static getTradeObject(
@@ -42,7 +43,7 @@ export class TradeFactory {
 
     public static getTradeParticipants(
         teamA = TeamFactory.getTeam("CREATOR_TEAM"),
-        teamB = TeamFactory.getTeam("RECIPIENT_TEAM", 2)
+        teamB = TeamFactory.getTeam("RECIPIENT_TEAM")
     ) {
         const creator = TradeFactory.getTradeCreator(teamA);
         const recipient = TradeFactory.getTradeRecipient(teamB);

--- a/tests/integration/TradeRoutes.test.ts
+++ b/tests/integration/TradeRoutes.test.ts
@@ -200,6 +200,22 @@ describe("Trade API endpoints", () => {
                 prospectIds.includes(player.id)
             );
         }, 2000);
+        it("should only return hydrated trades that match the statuses given", async () => {
+            const _draftTrade = await tradeDAO.createTrade(TradeFactory.getTrade());
+            const pendingTrade = await tradeDAO.createTrade(
+                TradeFactory.getTrade(undefined, undefined, TradeStatus.PENDING)
+            );
+            const requestedTrade = await tradeDAO.createTrade(
+                TradeFactory.getTrade(undefined, undefined, TradeStatus.REQUESTED)
+            );
+
+            const { body } = await getAllRequest(
+                `?hydrated=true&statuses[]=${TradeStatus.REQUESTED}&statuses[]=${TradeStatus.PENDING}`
+            );
+
+            expect(body).toBeArrayOfSize(2);
+            expect(body).toIncludeAllPartialMembers([{ tradeId: pendingTrade.id }, { tradeId: requestedTrade.id }]);
+        });
     });
 
     describe("GET /trades/:id (get one trade)", () => {

--- a/tests/integration/TradeRoutes.test.ts
+++ b/tests/integration/TradeRoutes.test.ts
@@ -22,7 +22,7 @@ import {
     makePostRequest,
     makePutRequest,
     ownerLoggedIn,
-    setupOwnerAndAdminUsers,
+    setupOwnerAndAdminUsers
 } from "./helpers";
 import {v4 as uuid} from "uuid";
 import * as TradeTracker from "../../src/csv/TradeTracker";
@@ -187,16 +187,17 @@ describe("Trade API endpoints", () => {
                 tradeCreator: testTrade.creator?.name,
                 tradeRecipients: testTrade.recipients.map(t => t.name),
             };
-            expect(body).toBeArrayOfSize(1);
-            expect(body[0]).toMatchObject(expected);
-            expect(body[0].tradeStatus).toEqual(testTrade.status?.toString());
-            expect((body[0] as HydratedTrade).tradedPicks).toSatisfyAll((pick: HydratedPick) =>
+            expect(body.total).toBe(1);
+            expect(body.trades).toBeArrayOfSize(1);
+            expect(body.trades[0]).toMatchObject(expected);
+            expect(body.trades[0].tradeStatus).toEqual(testTrade.status?.toString());
+            expect((body.trades[0] as HydratedTrade).tradedPicks).toSatisfyAll((pick: HydratedPick) =>
                 pickIds.includes(pick.id)
             );
-            expect((body[0] as HydratedTrade).tradedMajors).toSatisfyAll((player: HydratedMajorLeaguer) =>
+            expect((body.trades[0] as HydratedTrade).tradedMajors).toSatisfyAll((player: HydratedMajorLeaguer) =>
                 playerIds.includes(player.id)
             );
-            expect((body[0] as HydratedTrade).tradedMinors).toSatisfyAll((player: HydratedMinorLeaguer) =>
+            expect((body.trades[0] as HydratedTrade).tradedMinors).toSatisfyAll((player: HydratedMinorLeaguer) =>
                 prospectIds.includes(player.id)
             );
         }, 2000);
@@ -213,8 +214,9 @@ describe("Trade API endpoints", () => {
                 `?hydrated=true&statuses[]=${TradeStatus.REQUESTED}&statuses[]=${TradeStatus.PENDING}`
             );
 
-            expect(body).toBeArrayOfSize(2);
-            expect(body).toIncludeAllPartialMembers([{ tradeId: pendingTrade.id }, { tradeId: requestedTrade.id }]);
+            expect(body.total).toBe(2);
+            expect(body.trades).toBeArrayOfSize(2);
+            expect(body.trades).toIncludeAllPartialMembers([{ tradeId: pendingTrade.id }, { tradeId: requestedTrade.id }]);
         });
         it("should only return hydrated trades that the team given is involved in", async () => {
             const [teamA, teamB, teamC] = TeamFactory.getTeams(3);
@@ -234,8 +236,9 @@ describe("Trade API endpoints", () => {
                 `?hydrated=true&includesTeam=${teamA.name}`
             );
 
-            expect(body).toBeArrayOfSize(2);
-            expect(body).toIncludeAllPartialMembers([{ tradeId: tradeAB.id }, { tradeId: tradeBA.id }]);
+            expect(body.total).toBe(2);
+            expect(body.trades).toBeArrayOfSize(2);
+            expect(body.trades).toIncludeAllPartialMembers([{ tradeId: tradeAB.id }, { tradeId: tradeBA.id }]);
         });
         it("should handle returning hydrated trades with both team and status query filters", async () => {
             const [teamA, teamB, teamC] = TeamFactory.getTeams(3);
@@ -255,8 +258,9 @@ describe("Trade API endpoints", () => {
                 `?hydrated=true&includesTeam=${teamA.name}&statuses[]=${TradeStatus.REQUESTED}&statuses[]=${TradeStatus.PENDING}`
             );
 
-            expect(body).toBeArrayOfSize(1);
-            expect(body).toIncludeAllPartialMembers([{ tradeId: tradeBA.id }]);
+            expect(body.total).toBe(1);
+            expect(body.trades).toBeArrayOfSize(1);
+            expect(body.trades).toIncludeAllPartialMembers([{ tradeId: tradeBA.id }]);
         });
     });
 

--- a/tests/integration/TradeRoutes.test.ts
+++ b/tests/integration/TradeRoutes.test.ts
@@ -1,17 +1,17 @@
-import {Server} from "http";
+import { Server } from "http";
 import "jest-extended";
 import request from "supertest";
-import {redisClient} from "../../src/bootstrap/express";
+import { redisClient } from "../../src/bootstrap/express";
 import logger from "../../src/bootstrap/logger";
 import DraftPickDAO from "../../src/DAO/DraftPickDAO";
 import PlayerDAO from "../../src/DAO/PlayerDAO";
 import TeamDAO from "../../src/DAO/TeamDAO";
-import Trade, {TradeStatus} from "../../src/models/trade";
-import TradeParticipant, {TradeParticipantType} from "../../src/models/tradeParticipant";
+import Trade, { TradeStatus } from "../../src/models/trade";
+import TradeParticipant, { TradeParticipantType } from "../../src/models/tradeParticipant";
 import User from "../../src/models/user";
 import startServer from "../../src/bootstrap/app";
-import {TeamFactory} from "../factories/TeamFactory";
-import {TradeFactory} from "../factories/TradeFactory";
+import { TeamFactory } from "../factories/TeamFactory";
+import { TradeFactory } from "../factories/TradeFactory";
 import {
     adminLoggedIn,
     clearDb,
@@ -22,17 +22,17 @@ import {
     makePostRequest,
     makePutRequest,
     ownerLoggedIn,
-    setupOwnerAndAdminUsers
+    setupOwnerAndAdminUsers,
 } from "./helpers";
-import {v4 as uuid} from "uuid";
+import { v4 as uuid } from "uuid";
 import * as TradeTracker from "../../src/csv/TradeTracker";
-import {getConnection} from "typeorm";
+import { getConnection } from "typeorm";
 import TradeDAO from "../../src/DAO/TradeDAO";
 import TradeItem from "../../src/models/tradeItem";
-import {HydratedTrade} from "../../src/models/views/hydratedTrades";
-import {HydratedPick} from "../../src/models/views/hydratedPicks";
-import {HydratedMajorLeaguer} from "../../src/models/views/hydratedMajorLeaguers";
-import {HydratedMinorLeaguer} from "../../src/models/views/hydratedMinorLeaguers";
+import { HydratedTrade } from "../../src/models/views/hydratedTrades";
+import { HydratedPick } from "../../src/models/views/hydratedPicks";
+import { HydratedMajorLeaguer } from "../../src/models/views/hydratedMajorLeaguers";
+import { HydratedMinorLeaguer } from "../../src/models/views/hydratedMinorLeaguers";
 
 let app: Server;
 let adminUser: User;
@@ -216,7 +216,10 @@ describe("Trade API endpoints", () => {
 
             expect(body.total).toBe(2);
             expect(body.trades).toBeArrayOfSize(2);
-            expect(body.trades).toIncludeAllPartialMembers([{ tradeId: pendingTrade.id }, { tradeId: requestedTrade.id }]);
+            expect(body.trades).toIncludeAllPartialMembers([
+                { tradeId: pendingTrade.id },
+                { tradeId: requestedTrade.id },
+            ]);
         });
         it("should only return hydrated trades that the team given is involved in", async () => {
             const [teamA, teamB, teamC] = TeamFactory.getTeams(3);
@@ -232,9 +235,7 @@ describe("Trade API endpoints", () => {
             await tradeDAO.createTrade(tradeBA);
             await tradeDAO.createTrade(tradeBC);
 
-            const { body } = await getAllRequest(
-                `?hydrated=true&includesTeam=${teamA.name}`
-            );
+            const { body } = await getAllRequest(`?hydrated=true&includesTeam=${teamA.name}`);
 
             expect(body.total).toBe(2);
             expect(body.trades).toBeArrayOfSize(2);
@@ -251,7 +252,7 @@ describe("Trade API endpoints", () => {
 
             await teamDAO.createTeams([teamA, teamB, teamC]);
             await tradeDAO.createTrade(tradeAB);
-            await tradeDAO.createTrade({...tradeBA, status: TradeStatus.PENDING});
+            await tradeDAO.createTrade({ ...tradeBA, status: TradeStatus.PENDING });
             await tradeDAO.createTrade(tradeBC);
 
             const { body } = await getAllRequest(

--- a/tests/unit/DAO/TradeDAO.test.ts
+++ b/tests/unit/DAO/TradeDAO.test.ts
@@ -22,7 +22,7 @@ describe("TradeDAO", () => {
         update: jest.fn(),
     };
     const mockHydratedTradeDb: MockObj = {
-        find: jest.fn(),
+        findAndCount: jest.fn(),
     };
     const mockPlayerDao: MockObj = {
         getPlayerById: jest.fn(),
@@ -66,15 +66,15 @@ describe("TradeDAO", () => {
 
     it("returnHydratedTrades - should call find on the hydrated trades repo", async () => {
         await tradeDAO.returnHydratedTrades();
-        expect(mockHydratedTradeDb.find).toHaveBeenCalledTimes(1);
-        expect(mockHydratedTradeDb.find).toHaveBeenCalledWith({ order: { dateCreated: "DESC" }, take: 25, skip: 0 });
+        expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledTimes(1);
+        expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledWith({ order: { dateCreated: "DESC" }, take: 25, skip: 0 });
     });
 
     it("returnHydratedTrades - with status should include a valid where query", async () => {
         const pendingStatuses = [TradeStatus.PENDING, TradeStatus.REQUESTED];
         await tradeDAO.returnHydratedTrades(pendingStatuses);
-        expect(mockHydratedTradeDb.find).toHaveBeenCalledTimes(1);
-        expect(mockHydratedTradeDb.find).toHaveBeenCalledWith({
+        expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledTimes(1);
+        expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledWith({
             where: {
                 tradeStatus: {
                     _multipleParameters: true,
@@ -100,8 +100,8 @@ describe("TradeDAO", () => {
             },
         ];
         await tradeDAO.returnHydratedTrades(undefined, team.name);
-        expect(mockHydratedTradeDb.find).toHaveBeenCalledTimes(1);
-        expect(mockHydratedTradeDb.find).toHaveBeenCalledWith({
+        expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledTimes(1);
+        expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledWith({
             where: expectedParticipantsClause,
             order: { dateCreated: "DESC" },
             take: 25,
@@ -132,8 +132,8 @@ describe("TradeDAO", () => {
             },
         ];
         await tradeDAO.returnHydratedTrades(pendingStatuses, team.name);
-        expect(mockHydratedTradeDb.find).toHaveBeenCalledTimes(1);
-        expect(mockHydratedTradeDb.find).toHaveBeenCalledWith({
+        expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledTimes(1);
+        expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledWith({
             where: expectedParticipantsAndStatusClause,
             order: { dateCreated: "DESC" },
             take: 25,

--- a/tests/unit/DAO/TradeDAO.test.ts
+++ b/tests/unit/DAO/TradeDAO.test.ts
@@ -69,6 +69,25 @@ describe("TradeDAO", () => {
         expect(mockHydratedTradeDb.find).toHaveBeenCalledWith({ order: { dateCreated: "DESC" }, take: 25, skip: 0 });
     });
 
+    it("returnHydratedTrades - with status should include a where query", async () => {
+        const pendingStatuses = [TradeStatus.PENDING, TradeStatus.REQUESTED];
+        await tradeDAO.returnHydratedTrades(pendingStatuses);
+        expect(mockHydratedTradeDb.find).toHaveBeenCalledTimes(1);
+        expect(mockHydratedTradeDb.find).toHaveBeenCalledWith({
+            where: {
+                tradeStatus: {
+                    _multipleParameters: true,
+                    _type: "in",
+                    _useParameter: true,
+                    _value: pendingStatuses,
+                },
+            },
+            order: { dateCreated: "DESC" },
+            take: 25,
+            skip: 0,
+        });
+    });
+
     it("getTradeById - should call the db findOneOrFail once with id", async () => {
         mockTradeDb.findOneOrFail.mockResolvedValueOnce(testTrade);
         const res = await tradeDAO.getTradeById(testTrade.id!);

--- a/tests/unit/DAO/TradeDAO.test.ts
+++ b/tests/unit/DAO/TradeDAO.test.ts
@@ -67,7 +67,11 @@ describe("TradeDAO", () => {
     it("returnHydratedTrades - should call find on the hydrated trades repo", async () => {
         await tradeDAO.returnHydratedTrades();
         expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledTimes(1);
-        expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledWith({ order: { dateCreated: "DESC" }, take: 25, skip: 0 });
+        expect(mockHydratedTradeDb.findAndCount).toHaveBeenCalledWith({
+            order: { dateCreated: "DESC" },
+            take: 25,
+            skip: 0,
+        });
     });
 
     it("returnHydratedTrades - with status should include a valid where query", async () => {
@@ -113,12 +117,15 @@ describe("TradeDAO", () => {
         const pendingStatuses = [TradeStatus.PENDING, TradeStatus.REQUESTED];
         const team = TeamFactory.getTeam();
         const expectedParticipantsAndStatusClause = [
-            { tradeCreator: team.name, tradeStatus: {
+            {
+                tradeCreator: team.name,
+                tradeStatus: {
                     _multipleParameters: true,
                     _type: "in",
                     _useParameter: true,
                     _value: pendingStatuses,
-                } },
+                },
+            },
             {
                 tradeStatus: {
                     _multipleParameters: true,

--- a/tests/unit/api/routes/TradeController.test.ts
+++ b/tests/unit/api/routes/TradeController.test.ts
@@ -69,7 +69,7 @@ describe("TradeController", () => {
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(undefined, undefined, undefined, undefined);
             expect(mockTradeDAO.getAllTrades).toHaveBeenCalledTimes(0);
             expect(mockTradeDAO.hydrateTrade).toHaveBeenCalledTimes(0);
-            expect(res).toEqual({ trades: [testTrade as HydratedTrade], total: 1});
+            expect(res).toEqual({ trades: [testTrade as HydratedTrade], total: 1 });
         });
         it("should pass in any page parameters to hydrated trade call if present", async () => {
             mockTradeDAO.returnHydratedTrades.mockResolvedValueOnce([[testTrade as HydratedTrade], 1]); // TODO: update this test properly
@@ -77,7 +77,7 @@ describe("TradeController", () => {
 
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledTimes(1);
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(undefined, undefined, 50, 1);
-            expect(res).toEqual({ trades: [testTrade as HydratedTrade], total: 1});
+            expect(res).toEqual({ trades: [testTrade as HydratedTrade], total: 1 });
         });
         it("should pass in any search parameters to the hydrated trade call if present", async () => {
             const pendingStatuses = [TradeStatus.PENDING, TradeStatus.REQUESTED];
@@ -87,7 +87,7 @@ describe("TradeController", () => {
 
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledTimes(1);
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(pendingStatuses, team.name, 50, 1);
-            expect(res).toEqual({ trades: [testTrade as HydratedTrade], total: 1});
+            expect(res).toEqual({ trades: [testTrade as HydratedTrade], total: 1 });
         });
         it("should bubble up any errors from the DAO", async () => {
             mockTradeDAO.getAllTrades.mockImplementation(() => {

--- a/tests/unit/api/routes/TradeController.test.ts
+++ b/tests/unit/api/routes/TradeController.test.ts
@@ -66,7 +66,7 @@ describe("TradeController", () => {
             const res = await tradeController.getAllTrades(true);
 
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledTimes(1);
-            expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(undefined, undefined, undefined);
+            expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(undefined, undefined, undefined, undefined);
             expect(mockTradeDAO.getAllTrades).toHaveBeenCalledTimes(0);
             expect(mockTradeDAO.hydrateTrade).toHaveBeenCalledTimes(0);
             expect(res).toEqual([testTrade as HydratedTrade]);
@@ -76,16 +76,17 @@ describe("TradeController", () => {
             const res = await tradeController.getAllTrades(true, 50, 1);
 
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledTimes(1);
-            expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(undefined, 50, 1);
+            expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(undefined, undefined, 50, 1);
             expect(res).toEqual([testTrade as HydratedTrade]);
         });
-        it("should pass in an array of trade statuses if present", async () => {
+        it("should pass in any search parameters to the hydrated trade call if present", async () => {
             const pendingStatuses = [TradeStatus.PENDING, TradeStatus.REQUESTED];
+            const team = TeamFactory.getTeam();
             mockTradeDAO.returnHydratedTrades.mockResolvedValueOnce([testTrade as HydratedTrade]); // TODO: update this test properly to use a mock hydrated trade instead of a test trade
-            const res = await tradeController.getAllTrades(true, 50, 1, pendingStatuses);
+            const res = await tradeController.getAllTrades(true, 50, 1, pendingStatuses, team.name);
 
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledTimes(1);
-            expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(pendingStatuses, 50, 1);
+            expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(pendingStatuses, team.name, 50, 1);
             expect(res).toEqual([testTrade as HydratedTrade]);
         });
         it("should bubble up any errors from the DAO", async () => {

--- a/tests/unit/api/routes/TradeController.test.ts
+++ b/tests/unit/api/routes/TradeController.test.ts
@@ -62,32 +62,32 @@ describe("TradeController", () => {
             expect(res).toEqual([testTrade]);
         });
         it("should hydrate each trade before returning an array of trades if query param is present", async () => {
-            mockTradeDAO.returnHydratedTrades.mockResolvedValueOnce([testTrade as HydratedTrade]); // TODO: update this test properly
+            mockTradeDAO.returnHydratedTrades.mockResolvedValueOnce([[testTrade as HydratedTrade], 1]); // TODO: update this test properly
             const res = await tradeController.getAllTrades(true);
 
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledTimes(1);
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(undefined, undefined, undefined, undefined);
             expect(mockTradeDAO.getAllTrades).toHaveBeenCalledTimes(0);
             expect(mockTradeDAO.hydrateTrade).toHaveBeenCalledTimes(0);
-            expect(res).toEqual([testTrade as HydratedTrade]);
+            expect(res).toEqual({ trades: [testTrade as HydratedTrade], total: 1});
         });
         it("should pass in any page parameters to hydrated trade call if present", async () => {
-            mockTradeDAO.returnHydratedTrades.mockResolvedValueOnce([testTrade as HydratedTrade]); // TODO: update this test properly
+            mockTradeDAO.returnHydratedTrades.mockResolvedValueOnce([[testTrade as HydratedTrade], 1]); // TODO: update this test properly
             const res = await tradeController.getAllTrades(true, 50, 1);
 
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledTimes(1);
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(undefined, undefined, 50, 1);
-            expect(res).toEqual([testTrade as HydratedTrade]);
+            expect(res).toEqual({ trades: [testTrade as HydratedTrade], total: 1});
         });
         it("should pass in any search parameters to the hydrated trade call if present", async () => {
             const pendingStatuses = [TradeStatus.PENDING, TradeStatus.REQUESTED];
             const team = TeamFactory.getTeam();
-            mockTradeDAO.returnHydratedTrades.mockResolvedValueOnce([testTrade as HydratedTrade]); // TODO: update this test properly to use a mock hydrated trade instead of a test trade
+            mockTradeDAO.returnHydratedTrades.mockResolvedValueOnce([[testTrade as HydratedTrade], 1]); // TODO: update this test properly to use a mock hydrated trade instead of a test trade
             const res = await tradeController.getAllTrades(true, 50, 1, pendingStatuses, team.name);
 
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledTimes(1);
             expect(mockTradeDAO.returnHydratedTrades).toHaveBeenCalledWith(pendingStatuses, team.name, 50, 1);
-            expect(res).toEqual([testTrade as HydratedTrade]);
+            expect(res).toEqual({ trades: [testTrade as HydratedTrade], total: 1});
         });
         it("should bubble up any errors from the DAO", async () => {
             mockTradeDAO.getAllTrades.mockImplementation(() => {


### PR DESCRIPTION
- update seed scripts
- update /trades endpoint:
  - now you can filter by trade status (multi query param)
  - filter by team involved in the trade (single query param)
  - result is paginated and returns `total` as well