### PR TITLE
[BUGFIX][V2-Upgrade] player controller to prisma

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,252 +12,268 @@ https://github.com/typescript-eslint/tslint-to-eslint-config/blob/master/docs/FA
 Happy linting! 💖
 */
 module.exports = {
-    "env": {
-        "node": true,
-    },
-    "extends": [
-        "plugin:@typescript-eslint/recommended",
-        "plugin:@typescript-eslint/recommended-requiring-type-checking",
-        "prettier",
-        "plugin:eslint-comments/recommended",
-        "plugin:node/recommended",
-        "plugin:import/errors",
-        "plugin:import/warnings"
+  "env": {
+    "node": true,
+  },
+  "extends": [
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "prettier",
+    "plugin:eslint-comments/recommended",
+    "plugin:node/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": ["./tsconfig.eslint.json"],
+    "sourceType": "module",
+    "debugLevel": "true",
+  },
+  "ignorePatterns": ['.eslintrc.js', 'src/db/*', './src/scripts/**/*.ts', './tests/*', 'jest.ci-config.js', 'db_setup.js', 'jest.config.js', 'ormconfig.js'],
+  "plugins": [
+    "eslint-plugin-jsdoc",
+    "eslint-plugin-prefer-arrow",
+    "@typescript-eslint",
+    "@typescript-eslint/tslint"
+  ],
+  "rules": {
+    "@typescript-eslint/adjacent-overload-signatures": "error",
+    "@typescript-eslint/array-type": [
+      "error",
+      {
+        "default": "array"
+      }
     ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "project": ["./tsconfig.eslint.json"],
-        "sourceType": "module",
-        "debugLevel": "true",
-    },
-    "ignorePatterns": ['.eslintrc.js', 'src/db/*', './src/scripts/**/*.ts', './tests/*', 'jest.ci-config.js', 'db_setup.js', 'jest.config.js', 'ormconfig.js'],
-    "plugins": [
-        "eslint-plugin-jsdoc",
-        "eslint-plugin-prefer-arrow",
-        "@typescript-eslint",
-        "@typescript-eslint/tslint"
+    "@typescript-eslint/await-thenable": "error",
+    "@typescript-eslint/ban-ts-comment": "warn",
+    "@typescript-eslint/ban-types": [
+      "error",
+      {
+        "types": {
+          "Object": {
+            "message": "Avoid using the `Object` type. Did you mean `object`?"
+          },
+          "Function": {
+            "message": "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."
+          },
+          "Boolean": {
+            "message": "Avoid using the `Boolean` type. Did you mean `boolean`?"
+          },
+          "Number": {
+            "message": "Avoid using the `Number` type. Did you mean `number`?"
+          },
+          "String": {
+            "message": "Avoid using the `String` type. Did you mean `string`?"
+          },
+          "Symbol": {
+            "message": "Avoid using the `Symbol` type. Did you mean `symbol`?"
+          }
+        }
+      }
     ],
-    "rules": {
-        "@typescript-eslint/adjacent-overload-signatures": "error",
-        "@typescript-eslint/array-type": [
-            "error",
-            {
-                "default": "array"
-            }
-        ],
-        "@typescript-eslint/await-thenable": "error",
-        "@typescript-eslint/ban-ts-comment": "warn",
-        "@typescript-eslint/ban-types": [
-            "error",
-            {
-                "types": {
-                    "Object": {
-                        "message": "Avoid using the `Object` type. Did you mean `object`?"
-                    },
-                    "Function": {
-                        "message": "Avoid using the `Function` type. Prefer a specific function type, like `() => void`."
-                    },
-                    "Boolean": {
-                        "message": "Avoid using the `Boolean` type. Did you mean `boolean`?"
-                    },
-                    "Number": {
-                        "message": "Avoid using the `Number` type. Did you mean `number`?"
-                    },
-                    "String": {
-                        "message": "Avoid using the `String` type. Did you mean `string`?"
-                    },
-                    "Symbol": {
-                        "message": "Avoid using the `Symbol` type. Did you mean `symbol`?"
-                    }
-                }
-            }
-        ],
-        "@typescript-eslint/consistent-type-assertions": "error",
-        "@typescript-eslint/dot-notation": "error",
-        "@typescript-eslint/explicit-module-boundary-types": "warn",
-        "@typescript-eslint/indent": "off",
-        "@typescript-eslint/member-delimiter-style": [
-            "error",
-            {
-                "multiline": {
-                    "delimiter": "semi",
-                    "requireLast": true
-                },
-                "singleline": {
-                    "delimiter": "semi",
-                    "requireLast": false
-                }
-            }
-        ],
-        "@typescript-eslint/naming-convention": "error",
-        "@typescript-eslint/no-array-constructor": "error",
-        "@typescript-eslint/no-empty-function": "error",
-        "@typescript-eslint/no-empty-interface": "error",
-        "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-extra-non-null-assertion": "error",
-        "@typescript-eslint/no-extra-semi": "error",
-        "@typescript-eslint/no-floating-promises": "error",
-        "@typescript-eslint/no-for-in-array": "error",
-        "@typescript-eslint/no-implied-eval": "error",
-        "@typescript-eslint/no-inferrable-types": "error",
-        "@typescript-eslint/no-misused-new": "error",
-        "@typescript-eslint/no-misused-promises": "error",
-        "@typescript-eslint/no-namespace": "error",
-        "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
-        "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/no-parameter-properties": "off",
-        "@typescript-eslint/no-shadow": [
-            "error",
-            {
-                "hoist": "all"
-            }
-        ],
-        "@typescript-eslint/no-this-alias": "error",
-        "@typescript-eslint/no-unnecessary-type-assertion": "error",
-        "@typescript-eslint/no-unsafe-assignment": "error",
-        "@typescript-eslint/no-unsafe-call": "error",
-        "@typescript-eslint/no-unsafe-member-access": "error",
-        "@typescript-eslint/no-unsafe-return": "error",
-        "@typescript-eslint/no-unused-expressions": "error",
-        "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
-        "@typescript-eslint/no-use-before-define": "off",
-        "@typescript-eslint/no-var-requires": "error",
-        "@typescript-eslint/prefer-as-const": "error",
-        "@typescript-eslint/prefer-for-of": "error",
-        "@typescript-eslint/prefer-function-type": "error",
-        "@typescript-eslint/prefer-namespace-keyword": "error",
-        "@typescript-eslint/prefer-regexp-exec": "error",
-        "@typescript-eslint/quotes": [
-            "error",
-            "double",
-            {
-                "avoidEscape": true
-            }
-        ],
-        "@typescript-eslint/require-await": "warn",
-        "@typescript-eslint/restrict-plus-operands": "error",
-        "@typescript-eslint/restrict-template-expressions": "off",
-        "@typescript-eslint/semi": [
-            "error",
-            "always"
-        ],
-        "@typescript-eslint/triple-slash-reference": [
-            "error",
-            {
-                "path": "always",
-                "types": "prefer-import",
-                "lib": "always"
-            }
-        ],
-        "@typescript-eslint/tslint/config": [
-            "error",
-            {
-                "rules": {
-                    "whitespace": true
-                }
-            }
-        ],
-        "@typescript-eslint/type-annotation-spacing": "error",
-        "@typescript-eslint/unbound-method": "warn",
-        "@typescript-eslint/unified-signatures": "error",
-        "arrow-parens": [
-            "error",
-            "as-needed"
-        ],
-        "brace-style": [
-            "error",
-            "1tbs"
-        ],
-        "comma-dangle": [
-            "warn",
-            {
-                "objects": "always-multiline",
-                "arrays": "always-multiline",
-                "functions": "never"
-            }
-        ],
-        "complexity": "off",
-        "constructor-super": "error",
-        "dot-notation": "error",
-        "eqeqeq": [
-            "error",
-            "smart"
-        ],
-        "eslint-comments/no-unused-disable": "warn",
-        "eslint-comments/no-unlimited-disable": "warn",
-        "guard-for-in": "error",
-        "id-blacklist": [
-            "error",
-            "any",
-            "Number",
-            "number",
-            "String",
-            "string",
-            "Boolean",
-            "boolean",
-            "Undefined",
-            "undefined"
-        ],
-        "id-match": "error",
-        "import/no-unresolved": "off",
-        "indent": "off",
-        "jsdoc/check-alignment": "error",
-        "jsdoc/check-indentation": "error",
-        "jsdoc/newline-after-description": "error",
-        "max-classes-per-file": [
-            "error",
-            1
-        ],
-        "new-parens": "error",
-        "no-array-constructor": "off",
-        "no-bitwise": "error",
-        "no-caller": "error",
-        "no-cond-assign": "error",
-        "no-console": "error",
-        "no-debugger": "error",
-        "no-empty": "error",
-        "no-empty-function": "warn",
-        "no-eval": "error",
-        "no-extra-semi": "off",
-        "no-fallthrough": "off",
-        "no-implied-eval": "off",
-        "no-invalid-this": "off",
-        "no-new-wrappers": "error",
-        "no-shadow": "off",
-        "no-throw-literal": "error",
-        "no-trailing-spaces": "error",
-        "no-undef-init": "error",
-        "no-underscore-dangle": ["warn", {"allow": ["_id"]}],
-        "no-unsafe-finally": "error",
-        "no-unused-expressions": "error",
-        "no-unused-labels": "error",
-        "no-unused-vars": "off",
-        "no-use-before-define": "off",
-        "no-var": "error",
-        "node/no-unsupported-features/es-syntax": "off",
-        "node/no-missing-import": "off",
-        "node/no-unpublished-import": "warn",
-        "object-shorthand": "error",
-        "one-var": [
-            "error",
-            "never"
-        ],
-        "prefer-arrow/prefer-arrow-functions": "off",
-        "prefer-const": "error",
-        "quotes": "off",
-        "radix": "error",
-        "require-await": "off",
-        "semi": "error",
-        "spaced-comment": [
-            "error",
-            "always",
-            {
-                "markers": [
-                    "/"
-                ]
-            }
-        ],
-        "use-isnan": "error",
-        "valid-typeof": "off"
-    }
+    "@typescript-eslint/consistent-type-assertions": "error",
+    "@typescript-eslint/dot-notation": "error",
+    "@typescript-eslint/explicit-module-boundary-types": "warn",
+    "@typescript-eslint/indent": "off",
+    "@typescript-eslint/member-delimiter-style": [
+      "error",
+      {
+        "multiline": {
+          "delimiter": "semi",
+          "requireLast": true
+        },
+        "singleline": {
+          "delimiter": "semi",
+          "requireLast": false
+        }
+      }
+    ],
+    "@typescript-eslint/naming-convention": ["error", {
+      selector: 'default',
+      format: ['camelCase'],
+      leadingUnderscore: 'allow',
+      trailingUnderscore: 'allow',
+      filter: {regex: "^(AND|OR|Players|Users|Teams)$", match: false}
+    },
+      {
+        selector: 'variable',
+        format: ['camelCase', 'UPPER_CASE'],
+        leadingUnderscore: 'allow',
+        trailingUnderscore: 'allow',
+      },
+      {
+        selector: 'typeLike',
+        format: ['PascalCase'],
+      }],
+    "@typescript-eslint/no-array-constructor": "error",
+    "@typescript-eslint/no-empty-function": "error",
+    "@typescript-eslint/no-empty-interface": "error",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-extra-non-null-assertion": "error",
+    "@typescript-eslint/no-extra-semi": "error",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-for-in-array": "error",
+    "@typescript-eslint/no-implied-eval": "error",
+    "@typescript-eslint/no-inferrable-types": "error",
+    "@typescript-eslint/no-misused-new": "error",
+    "@typescript-eslint/no-misused-promises": "error",
+    "@typescript-eslint/no-namespace": "error",
+    "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-parameter-properties": "off",
+    "@typescript-eslint/no-shadow": [
+      "error",
+      {
+        "hoist": "all"
+      }
+    ],
+    "@typescript-eslint/no-this-alias": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    "@typescript-eslint/no-unsafe-assignment": "error",
+    "@typescript-eslint/no-unsafe-call": "error",
+    "@typescript-eslint/no-unsafe-member-access": "error",
+    "@typescript-eslint/no-unsafe-return": "error",
+    "@typescript-eslint/no-unused-expressions": "error",
+    "@typescript-eslint/no-unused-vars": ["warn", {"argsIgnorePattern": "^_"}],
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/no-var-requires": "error",
+    "@typescript-eslint/prefer-as-const": "error",
+    "@typescript-eslint/prefer-for-of": "error",
+    "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/prefer-namespace-keyword": "error",
+    "@typescript-eslint/prefer-regexp-exec": "error",
+    "@typescript-eslint/quotes": [
+      "error",
+      "double",
+      {
+        "avoidEscape": true
+      }
+    ],
+    "@typescript-eslint/require-await": "warn",
+    "@typescript-eslint/restrict-plus-operands": "error",
+    "@typescript-eslint/restrict-template-expressions": "off",
+    "@typescript-eslint/semi": [
+      "error",
+      "always"
+    ],
+    "@typescript-eslint/triple-slash-reference": [
+      "error",
+      {
+        "path": "always",
+        "types": "prefer-import",
+        "lib": "always"
+      }
+    ],
+    "@typescript-eslint/tslint/config": [
+      "error",
+      {
+        "rules": {
+          "whitespace": true
+        }
+      }
+    ],
+    "@typescript-eslint/type-annotation-spacing": "error",
+    "@typescript-eslint/unbound-method": "warn",
+    "@typescript-eslint/unified-signatures": "error",
+    "arrow-parens": [
+      "error",
+      "as-needed"
+    ],
+    "brace-style": [
+      "error",
+      "1tbs"
+    ],
+    "comma-dangle": [
+      "warn",
+      {
+        "objects": "always-multiline",
+        "arrays": "always-multiline",
+        "functions": "never"
+      }
+    ],
+    "complexity": "off",
+    "constructor-super": "error",
+    "dot-notation": "error",
+    "eqeqeq": [
+      "error",
+      "smart"
+    ],
+    "eslint-comments/no-unused-disable": "warn",
+    "eslint-comments/no-unlimited-disable": "warn",
+    "guard-for-in": "error",
+    "id-blacklist": [
+      "error",
+      "any",
+      "Number",
+      "number",
+      "String",
+      "string",
+      "Boolean",
+      "boolean",
+      "Undefined",
+      "undefined"
+    ],
+    "id-match": "error",
+    "import/no-unresolved": "off",
+    "indent": "off",
+    "jsdoc/check-alignment": "error",
+    "jsdoc/check-indentation": "error",
+    "jsdoc/newline-after-description": "error",
+    "max-classes-per-file": [
+      "error",
+      1
+    ],
+    "new-parens": "error",
+    "no-array-constructor": "off",
+    "no-bitwise": "error",
+    "no-caller": "error",
+    "no-cond-assign": "error",
+    "no-console": "error",
+    "no-debugger": "error",
+    "no-empty": "error",
+    "no-empty-function": "warn",
+    "no-eval": "error",
+    "no-extra-semi": "off",
+    "no-fallthrough": "off",
+    "no-implied-eval": "off",
+    "no-invalid-this": "off",
+    "no-new-wrappers": "error",
+    "no-shadow": "off",
+    "no-throw-literal": "error",
+    "no-trailing-spaces": "error",
+    "no-undef-init": "error",
+    "no-underscore-dangle": ["warn", {"allow": ["_id"]}],
+    "no-unsafe-finally": "error",
+    "no-unused-expressions": "error",
+    "no-unused-labels": "error",
+    "no-unused-vars": "off",
+    "no-use-before-define": "off",
+    "no-var": "error",
+    "node/no-unsupported-features/es-syntax": "off",
+    "node/no-missing-import": "off",
+    "node/no-unpublished-import": "warn",
+    "object-shorthand": "error",
+    "one-var": [
+      "error",
+      "never"
+    ],
+    "prefer-arrow/prefer-arrow-functions": "off",
+    "prefer-const": "error",
+    "quotes": "off",
+    "radix": "error",
+    "require-await": "off",
+    "semi": "error",
+    "spaced-comment": [
+      "error",
+      "always",
+      {
+        "markers": [
+          "/"
+        ]
+      }
+    ],
+    "use-isnan": "error",
+    "valid-typeof": "off"
+  }
 };

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ serve: ## Serve the node server statically (no restarting on file changes)
 typecheck: ## Check for type errors that would cause failures to build
 	npx tsc --noEmit --incremental false
 
-fullcheck: lint-fix format typecheck lint
+fullcheck: lint-fix typecheck format lint
 
 # |----------- DATABASE MIGRATION SCRIPTS ---------|
 generate-migration: ## Generate a new migration file with name=MIGRATION_NAME and using config for ENV

--- a/jestSetupFile.mjs
+++ b/jestSetupFile.mjs
@@ -1,5 +1,10 @@
 const dotenvConfig = require('dotenv').config
 const resolvePath = require("path").resolve
+const { mockDeep } = require("jest-mock-extended");
+const { rollbar } = require("./src/bootstrap/rollbar");
+ 
+// mock rollbar throughout the tests
+jest.mock("./src/bootstrap/rollbar");
 
 // add all jest-extended matchers
 const matchers = require('jest-extended/all');

--- a/src/DAO/PlayerDAO.ts
+++ b/src/DAO/PlayerDAO.ts
@@ -11,6 +11,8 @@ import {
 } from "typeorm";
 import Player from "../models/player";
 import Team from "../models/team";
+import logger from "../bootstrap/logger";
+import { inspect } from "util";
 
 interface PlayerDeleteResult extends DeleteResult {
     raw: Player[];
@@ -44,6 +46,8 @@ export default class PlayerDAO {
         const leagueTeamId = query.leagueTeamId;
         let options: FindManyOptions<Player> = {};
         let where;
+        logger.debug(`initial query: ${inspect(query)}`);
+
         if (leagueTeamId) {
             delete query.leagueTeamId;
             const leagueTeam: FindOptionsWhere<Team> = { id: leagueTeamId };
@@ -53,6 +57,7 @@ export default class PlayerDAO {
         }
 
         options = limit ? { where, take: limit } : { where };
+        logger.debug(`initial options: ${inspect(options)}`);
         return await this.playerDb.find(options);
     }
 

--- a/src/DAO/v2/PlayerDAO.ts
+++ b/src/DAO/v2/PlayerDAO.ts
@@ -1,0 +1,69 @@
+import { PrismaClient, Player } from "@prisma/client";
+import { convertParamsToWhereQuery } from "./helpers";
+import logger from "../../bootstrap/logger";
+import { inspect } from "util";
+
+export default class PlayerDAO {
+    private readonly playerDb: PrismaClient["player"];
+
+    constructor(playerDb: PrismaClient["player"] | undefined) {
+        if (!playerDb) {
+            throw new Error("PlayerDAO must be initialized with a PrismaClient model instance!");
+        }
+        this.playerDb = playerDb;
+    }
+
+    public async getAllPlayers(): Promise<Player[]> {
+        return await this.playerDb.findMany({ orderBy: { id: "asc" } });
+    }
+
+    public async findPlayers(params: string[]): Promise<Player[]> {
+        const query = normalizePlayerQuery(convertParamsToWhereQuery(params));
+        logger.debug(`finding players with normalized query: ${inspect(query)}`);
+
+        return await this.playerDb.findMany({
+            where: {
+                AND: query,
+            },
+            orderBy: { id: "asc" },
+        });
+    }
+}
+
+function normalizePlayerQuery(query: { [field: string]: string }[]) {
+    return query.reduce((queryAcc: { [field: string]: string }[], kvp: { [field: string]: string }) => {
+        const fields = Object.keys(kvp);
+        if (fields.length > 1) {
+            logger.error("Each query field should only have a single object");
+            return [];
+        }
+
+        const field = fields[0];
+        const currQuery: { [field: string]: string } = {};
+        if (field === "meta") {
+            // drop any queries for meta since it's a bit more complicated than a straight up where equals
+            return queryAcc;
+        } else if (field === "league") {
+            // Prisma expects league to be "MAJORS" or "MINORS"
+            if (["MAJORS", "MINORS"].includes(kvp[field].toUpperCase())) {
+                currQuery[field] = kvp[field].toUpperCase();
+                return [...queryAcc, currQuery];
+            } else if (["MAJOR", "MINOR"].includes(kvp[field].toUpperCase())) {
+                currQuery[field] = kvp[field].toUpperCase() + "S";
+                return [...queryAcc, currQuery];
+            } else if ([1, 2, "1", "2"].includes(kvp[field])) {
+                if (kvp[field].toString() === "1") {
+                    currQuery[field] = "MAJORS";
+                } else if (kvp[field].toString() === "2") {
+                    currQuery[field] = "MINORS";
+                }
+                return [...queryAcc, currQuery];
+            } else {
+                return [];
+            }
+        } else {
+            currQuery[field] = kvp[field];
+            return [...queryAcc, currQuery];
+        }
+    }, []);
+}

--- a/src/DAO/v2/PlayerDAO.ts
+++ b/src/DAO/v2/PlayerDAO.ts
@@ -30,7 +30,7 @@ export default class PlayerDAO {
     }
 }
 
-function normalizePlayerQuery(query: { [field: string]: string }[]) {
+function normalizePlayerQuery(query: { [field: string]: string }[]): { [field: string]: string }[] {
     return query.reduce((queryAcc: { [field: string]: string }[], kvp: { [field: string]: string }) => {
         const fields = Object.keys(kvp);
         if (fields.length > 1) {

--- a/src/DAO/v2/UserDAO.ts
+++ b/src/DAO/v2/UserDAO.ts
@@ -1,5 +1,5 @@
 import { PrismaClient, User } from "@prisma/client";
-import exclude from "./helpers";
+import { exclude } from "./helpers";
 
 export type PublicUser = Omit<User, "password">;
 
@@ -14,11 +14,11 @@ export default class UserDAO {
     }
 
     // TODO: Possibly these static functions would go into their own class at some point; or maybe we keep it flat like this
-    static publicUser(user: User) {
+    static publicUser(user: User): Omit<User, "password"> {
         return exclude(user, "password");
     }
 
-    static publicUsers(users: User[]) {
+    static publicUsers(users: User[]): Omit<User, "password">[] {
         return users.map(user => UserDAO.publicUser(user));
     }
 

--- a/src/DAO/v2/helpers.ts
+++ b/src/DAO/v2/helpers.ts
@@ -1,6 +1,13 @@
-export default function exclude<T, Key extends keyof T>(model: T, ...keys: Key[]): Omit<T, Key> {
+export function exclude<T, Key extends keyof T>(model: T, ...keys: Key[]): Omit<T, Key> {
     for (const key of keys) {
         delete model[key];
     }
     return model;
+}
+
+export function convertParamsToWhereQuery(params: string[]): { [field: string]: string }[] {
+    return params.map(paramStr => {
+        const [field, value] = paramStr.split(".");
+        return { [field]: value };
+    });
 }

--- a/src/api/routes/EspnController.ts
+++ b/src/api/routes/EspnController.ts
@@ -34,7 +34,7 @@ export default class EspnController {
         @Req() request?: Request
     ): Promise<EspnFantasyTeam[]> {
         rollbar.info("getAllEspnTeams", { year }, request);
-        logger.debug("get all ESPN teams endpoint");
+        logger.debug(`get all ESPN teams endpoint (year=${year || new Date().getFullYear()})`);
         const teams = await this.api.getAllLeagueTeams(year || new Date().getFullYear());
         logger.debug(`got ${teams.length} teams`);
         return teams;

--- a/src/api/routes/PlayerController.ts
+++ b/src/api/routes/PlayerController.ts
@@ -24,6 +24,7 @@ import { Role } from "../../models/user";
 import { cleanupQuery, fileUploadOptions as uploadOpts, UUID_PATTERN } from "../helpers/ApiHelpers";
 import { rollbar } from "../../bootstrap/rollbar";
 import { Request } from "express";
+import { In } from "typeorm";
 
 @JsonController("/players")
 export default class PlayerController {
@@ -38,9 +39,9 @@ export default class PlayerController {
     @Get("/")
     public async getAllPlayers(@QueryParam("include") include?: string[], @Req() request?: Request): Promise<Player[]> {
         rollbar.info("getAllPlayers", { include }, request);
-        logger.debug("get all players endpoint" + `${include ? ` with params: ${include}` : ""}`);
+        logger.debug("get all players endpoint" + `${include ? ` with params: ${inspect(include)}` : ""}`);
         let players: Player[] = [];
-        if (include) {
+        if (include?.length) {
             const params = getAllPlayersQuery(include);
             players = (await this.dao.findPlayers(params)) || players;
         } else {
@@ -135,5 +136,10 @@ function getAllPlayersQuery(includes: string[]) {
         minors: PlayerLeagueType.MINOR,
         majors: PlayerLeagueType.MAJOR,
     };
-    return includes.map(include => ({ league: keywordToLevelMap[include] }));
+
+    if (includes.length === 1) {
+        return { league: keywordToLevelMap[includes[0]] };
+    } else {
+        return { league: In(includes.map(include => keywordToLevelMap[include])) };
+    }
 }

--- a/src/api/routes/v2/PlayerController.ts
+++ b/src/api/routes/v2/PlayerController.ts
@@ -1,0 +1,45 @@
+import { Get, JsonController, QueryParam, Req } from "routing-controllers";
+import Players from "../../../DAO/v2/PlayerDAO";
+import { PrismaClient, Player } from "@prisma/client";
+import { ExpressAppSettings } from "../../../bootstrap/express";
+import logger from "../../../bootstrap/logger";
+import { rollbar } from "../../../bootstrap/rollbar";
+import { inspect } from "util";
+import { Request } from "express";
+
+@JsonController("/v2/players")
+export default class V2PlayerController {
+    private daoInstance: Players | undefined;
+
+    private dao(req: Request | undefined) {
+        if (this.daoInstance) {
+            return this.daoInstance;
+        } else if (!req) {
+            throw new Error("HTTP request object required!");
+        } else {
+            const appSettings: ExpressAppSettings = req.app.settings as ExpressAppSettings;
+            this.daoInstance = new Players(appSettings?.prisma?.player as PrismaClient["player"]);
+            return this.daoInstance;
+        }
+    }
+
+    constructor(daoInstance?: Players) {
+        this.daoInstance = daoInstance;
+    }
+
+    @Get("/")
+    public async getAll(@QueryParam("where") whereParams?: string[], @Req() req?: Request): Promise<Player[]> {
+        rollbar.info("getAllPlayers", { whereParams }, req);
+        logger.debug("get all players endpoint" + `${whereParams ? ` with params: ${inspect(whereParams)}` : ""}`);
+
+        let players: Player[] = [];
+        if (whereParams?.length) {
+            players = await this.dao(req).findPlayers(whereParams);
+        } else {
+            players = await this.dao(req).getAllPlayers();
+        }
+
+        logger.debug(`got ${players.length} players`);
+        return players;
+    }
+}

--- a/src/api/routes/v2/UserController.ts
+++ b/src/api/routes/v2/UserController.ts
@@ -4,6 +4,7 @@ import logger from "../../../bootstrap/logger";
 import Users, { PublicUser } from "../../../DAO/v2/UserDAO";
 import { PrismaClient } from "@prisma/client";
 import { ExpressAppSettings } from "../../../bootstrap/express";
+import { rollbar } from "../../../bootstrap/rollbar";
 
 @JsonController("/v2/users")
 export default class V2UserController {
@@ -27,8 +28,11 @@ export default class V2UserController {
 
     @Get("/")
     public async getAll(@Req() req?: Request): Promise<PublicUser[]> {
+        rollbar.info("getAllUsers", req);
         logger.debug("V2: get all users endpoint");
+
         const users = await this.dao(req).getAllUsers();
+
         logger.debug(`got ${users.length} users`);
         return users;
     }

--- a/src/bootstrap/express.ts
+++ b/src/bootstrap/express.ts
@@ -22,7 +22,9 @@ app.use(express.json({ limit: "10mb" }));
 app.use(express.urlencoded({ extended: true }));
 app.use(morgan("dev", { stream: { write: message => logger.info(message.trim()) } }));
 app.use(responseTime());
-app.use(rollbar.errorHandler());
+if (process.env.NODE_ENV !== "test") {
+    app.use(rollbar.errorHandler());
+}
 
 export interface ExpressAppSettings {
     prisma: PrismaClient | undefined;

--- a/src/bootstrap/rollbar.ts
+++ b/src/bootstrap/rollbar.ts
@@ -1,10 +1,10 @@
 import Rollbar from "rollbar";
 
 export const rollbar = new Rollbar({
-    accessToken: process.env.ROLLBAR_TOKEN,
-    environment: process.env.ORM_CONFIG,
-    autoInstrument: process.env.NODE_ENV === "test" ? false : true, // may want to extend this in the future: https://docs.rollbar.com/docs/nodejs#telemetry; turning off for test since it causes too many eventEmitter listeners (memory hog)
-    captureEmail: true,
-    captureUsername: true,
-    captureUncaught: true,
-});
+              accessToken: process.env.ROLLBAR_TOKEN,
+              environment: process.env.ORM_CONFIG,
+              autoInstrument: process.env.NODE_ENV === "test" ? false : true, // may want to extend this in the future: https://docs.rollbar.com/docs/nodejs#telemetry; turning off for test since it causes too many eventEmitter listeners (memory hog)
+              captureEmail: true,
+              captureUsername: true,
+              captureUncaught: true,
+          });

--- a/src/bootstrap/rollbar.ts
+++ b/src/bootstrap/rollbar.ts
@@ -1,10 +1,10 @@
 import Rollbar from "rollbar";
 
 export const rollbar = new Rollbar({
-              accessToken: process.env.ROLLBAR_TOKEN,
-              environment: process.env.ORM_CONFIG,
-              autoInstrument: process.env.NODE_ENV === "test" ? false : true, // may want to extend this in the future: https://docs.rollbar.com/docs/nodejs#telemetry; turning off for test since it causes too many eventEmitter listeners (memory hog)
-              captureEmail: true,
-              captureUsername: true,
-              captureUncaught: true,
-          });
+    accessToken: process.env.ROLLBAR_TOKEN,
+    environment: process.env.ORM_CONFIG,
+    autoInstrument: process.env.NODE_ENV === "test" ? false : true, // may want to extend this in the future: https://docs.rollbar.com/docs/nodejs#telemetry; turning off for test since it causes too many eventEmitter listeners (memory hog)
+    captureEmail: true,
+    captureUsername: true,
+    captureUncaught: true,
+});

--- a/src/scripts/oneoffs/prismaScratch.ts
+++ b/src/scripts/oneoffs/prismaScratch.ts
@@ -1,15 +1,38 @@
 /* eslint-disable */
 
 import initializeDb from "../../bootstrap/prisma-db";
+import initializePrisma from "../../bootstrap/prisma-db";
+import logger from "../../bootstrap/logger";
 
 const prisma = initializeDb(true);
 
 async function main() {
-    const schema = "test";
-    const tableNames = await prisma.$queryRaw<
-        { tablename: string }[]
-    >`SELECT tablename FROM pg_tables WHERE schemaname=${schema}`;
-    console.log(tableNames);
+    // const schema = "dev";
+    // const tableNames = await prisma.$queryRaw<
+    //     { tablename: string }[]
+    // >`SELECT tablename FROM pg_tables WHERE schemaname=${schema}`;
+    // console.log(tableNames);
+
+    const prisma = initializePrisma(true);
+    const playerDb = prisma.player;
+
+    const allPlayers = await playerDb.findMany({ orderBy: { id: "desc" } });
+    console.dir(allPlayers);
+
+    const query = convertParamsToQuery(["league.MINORS", "name.Franklin Perez"]);
+    const minorsOnly = await playerDb.findMany({
+        where: {
+            AND: query,
+        },
+    });
+    console.dir(minorsOnly);
+}
+
+function convertParamsToQuery(params: string[]): { [field: string]: string }[] {
+    return params.map(paramStr => {
+        const [field, value] = paramStr.split(".");
+        return { [field]: value };
+    });
 }
 
 main()

--- a/tests/factories/PlayerFactory.ts
+++ b/tests/factories/PlayerFactory.ts
@@ -1,5 +1,7 @@
 import Player, { PlayerLeagueType } from "../../src/models/player";
+import { Player as PrismaPlayer, PlayerLeagueLevel } from "@prisma/client";
 import { v4 as uuid } from "uuid";
+import { faker } from "@faker-js/faker";
 
 export class PlayerFactory {
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -11,5 +13,23 @@ export class PlayerFactory {
 
     public static getPlayer(name = PlayerFactory.NAME, league = PlayerLeagueType.MINOR, rest = {}) {
         return new Player(PlayerFactory.getPlayerObject(name, league, rest));
+    }
+
+    public static getPrismaPlayer(
+        name = faker.name.fullName(),
+        league = PlayerLeagueLevel.MINORS,
+        rest = {}
+    ): PrismaPlayer {
+        return {
+            id: uuid(),
+            dateCreated: new Date(),
+            dateModified: new Date(),
+            name,
+            league,
+            mlbTeam: null,
+            meta: {},
+            playerDataId: parseInt(faker.random.numeric(5), 10),
+            leagueTeamId: null,
+        };
     }
 }

--- a/tests/integration/EspnRoutes.test.ts
+++ b/tests/integration/EspnRoutes.test.ts
@@ -1,3 +1,4 @@
+import "jest-extended";
 import { Server } from "http";
 import request from "supertest";
 import { redisClient } from "../../src/bootstrap/express";
@@ -53,7 +54,8 @@ describe("ESPN API endpoints", () => {
                 return makeGetRequest(agent, `/espn/teams${yearParam}`, status);
             };
 
-        it("should return all teams in the default year", async () => {
+        // TODO: Skip for now because default year would be 2023, and there's no season on espn for that yet.
+        it.skip("should return all teams in the default year", async () => {
             const { body } = await adminLoggedIn(getAllRequest(), app);
             expect(body).toBeArray();
             // There are other keys, but these are the ones we definitely want to know if they're gone
@@ -81,7 +83,8 @@ describe("ESPN API endpoints", () => {
                 return makeGetRequest(agent, `/espn/members${yearParam}`, status);
             };
 
-        it("should return all members in the default year", async () => {
+        // TODO: Skip for now because default year would be 2023, and there's no season on espn for that yet.
+        it.skip("should return all members in the default year", async () => {
             const { body } = await adminLoggedIn(getAllRequest(), app);
             expect(body).toBeArray();
             expect(body[0]).toContainAllKeys(["id", "isLeagueManager", "displayName"]);

--- a/tests/integration/v2/PlayerRoutes.test.ts
+++ b/tests/integration/v2/PlayerRoutes.test.ts
@@ -1,0 +1,108 @@
+import { Server } from "http";
+import request from "supertest";
+import "jest-extended";
+import { redisClient } from "../../../src/bootstrap/express";
+import logger from "../../../src/bootstrap/logger";
+import initializeDb from "../../../src/bootstrap/prisma-db";
+import startServer from "../../../src/bootstrap/app";
+import { clearPrismaDb, makeGetRequest, setupOwnerAndAdminUsers } from "../helpers";
+import { PrismaClient, Player } from "@prisma/client";
+import User from "../../../src/models/user";
+import { PlayerFactory } from "../../factories/PlayerFactory";
+import PlayerDAO from "../../../src/DAO/PlayerDAO";
+import PlayerModel, { PlayerLeagueType } from "../../../src/models/player";
+
+let app: Server;
+let prismaConn: PrismaClient;
+let ownerUser: User;
+let adminUser: User;
+let playerDao: PlayerDAO;
+
+async function shutdown() {
+    try {
+        await redisClient.disconnect();
+    } catch (err) {
+        logger.error(`Error while closing redis: ${err}`);
+    }
+}
+
+beforeAll(async () => {
+    logger.debug("~~~~~~[V2] PLAYER ROUTES BEFORE ALL~~~~~~");
+    app = await startServer();
+    logger.debug("server started");
+    prismaConn = initializeDb(true);
+    logger.debug("prisma conn started");
+    // Create admin and owner users in db for rest of this suite's use
+    [adminUser, ownerUser] = await setupOwnerAndAdminUsers();
+    logger.debug("users created");
+
+    playerDao = new PlayerDAO();
+
+    return app;
+    // TODO: Hopefully we can remove the timeout after not relying on TypeORM
+}, 40000);
+
+afterAll(async () => {
+    logger.debug("~~~~~~[V2] PLAYER ROUTES AFTER ALL~~~~~~");
+    const shutdownRedis = await shutdown();
+    if (app) {
+        app.close(() => {
+            logger.debug("CLOSED SERVER");
+        });
+    }
+    return shutdownRedis;
+});
+
+describe("Player V2 API Endpoints", () => {
+    const testPlayers = [
+        PlayerFactory.getPlayerObject("Akosua", PlayerLeagueType.MINOR),
+        PlayerFactory.getPlayerObject("Aaron Judge", PlayerLeagueType.MAJOR),
+        PlayerFactory.getPlayerObject("Jacob Kazama", PlayerLeagueType.MINOR),
+    ];
+    let savedPlayers: PlayerModel[];
+
+    beforeEach(async () => {
+        // TODO: Use prisma factory once we've switched over that dao function
+        savedPlayers = await playerDao.createPlayers(testPlayers);
+    });
+    afterEach(async () => {
+        return await clearPrismaDb(prismaConn);
+    });
+
+    describe("GET /v2/players{?where[]} (get all players)", () => {
+        const getAllRequest = (param = "", status = 200) => makeGetRequest(request(app), `/v2/players${param}`, status);
+
+        it("should return an array of all the users in the db", async () => {
+            const { body } = await getAllRequest();
+            expect(body).toBeArrayOfSize(testPlayers.length);
+            expect(body.map((p: Player) => p.id)).toSatisfyAll(id => testPlayers.map(tp => tp.id).includes(id));
+        });
+        it("should return an array of all players filtered by a given field", async () => {
+            const { body: filterByNameBody } = await getAllRequest("?where[]=name." + testPlayers[0].name);
+            const { body: filterByLeagueBody } = await getAllRequest("?where[]=league.minors");
+            const { body: filterByNoneBody } = await getAllRequest("?where[]=");
+
+            expect(filterByNameBody).toBeArrayOfSize(1);
+            expect(filterByNameBody[0].id).toEqual(savedPlayers[0].id);
+
+            expect(filterByLeagueBody).toBeArrayOfSize(2);
+            expect(filterByLeagueBody.map((p: Player) => p.id)).toSatisfyAll(id =>
+                [savedPlayers[0].id, savedPlayers[2].id].includes(id)
+            );
+
+            expect(filterByNoneBody).toBeArrayOfSize(3);
+            expect(filterByNoneBody.map((p: Player) => p.id)).toSatisfyAll(id =>
+                savedPlayers.map(tp => tp.id).includes(id)
+            );
+        });
+        it("should combine where parameters using AND logic", async () => {
+            const { body: validFilterBody } = await getAllRequest("?where[]=name.Akosua&where[]=league.minors");
+            const { body: missingFilterBody } = await getAllRequest("?where[]=name.Akosua&where[]=league.majors");
+
+            expect(validFilterBody).toBeArrayOfSize(1);
+            expect(validFilterBody[0].id).toEqual(savedPlayers[0].id);
+
+            expect(missingFilterBody).toBeArrayOfSize(0);
+        });
+    });
+});

--- a/tests/unit/DAO/v2/PlayerDAO.test.ts
+++ b/tests/unit/DAO/v2/PlayerDAO.test.ts
@@ -1,0 +1,63 @@
+import { PrismaClient, Player } from "@prisma/client";
+import { PlayerFactory } from "../../../factories/PlayerFactory";
+import { mockDeep, mockClear } from "jest-mock-extended";
+import PlayerDAO from "../../../../src/DAO/v2/PlayerDAO";
+import logger from "../../../../src/bootstrap/logger";
+
+describe("[PRISMA] PlayerDAO", () => {
+    const testPlayer: Player = PlayerFactory.getPrismaPlayer();
+    const prisma = mockDeep<PrismaClient["player"]>();
+    const Players: PlayerDAO = new PlayerDAO(prisma);
+
+    afterEach(() => {
+        mockClear(prisma);
+    });
+
+    beforeAll(() => {
+        logger.debug("~~~~~~PRISMA PLAYER DAO TESTS BEGIN~~~~~~");
+    });
+    afterAll(() => {
+        logger.debug("~~~~~~PRISMA PLAYER DAO TESTS COMPLETE~~~~~~");
+    });
+
+    describe("getAllPlayers", () => {
+        it("should return an array of players by calling the db", async () => {
+            prisma.findMany.mockResolvedValueOnce([testPlayer]);
+            const sortOptions = { orderBy: { id: "asc" } };
+
+            const res = await Players.getAllPlayers();
+
+            expect(prisma.findMany).toHaveBeenCalledTimes(1);
+            expect(prisma.findMany).toHaveBeenCalledWith(sortOptions);
+            expect(res).toEqual([testPlayer]);
+        });
+    });
+
+    describe("findPlayers", () => {
+        it("should return an array of players matching the given filter using a Where AND query", async () => {
+            prisma.findMany.mockResolvedValueOnce([testPlayer]);
+            const sortOptions = { orderBy: { id: "asc" } };
+            const expectedWhere = { where: { AND: [{ mlbTeam: "LAD" }] } };
+            const inputParam = ["mlbTeam.LAD"];
+
+            const res = await Players.findPlayers(inputParam);
+
+            expect(prisma.findMany).toHaveBeenCalledTimes(1);
+            expect(prisma.findMany).toHaveBeenCalledWith({ ...sortOptions, ...expectedWhere });
+            expect(res).toEqual([testPlayer]);
+        });
+
+        it("should return pass in an array of WHERE AND objects if multiple input params are given", async () => {
+            prisma.findMany.mockResolvedValueOnce([testPlayer]);
+            const sortOptions = { orderBy: { id: "asc" } };
+            const expectedWhere = { where: { AND: [{ mlbTeam: "LAD", name: "Joseph" }] } };
+            const inputParam = ["mlbTeam.LAD", "name.Joseph"];
+
+            const res = await Players.findPlayers(inputParam);
+
+            expect(prisma.findMany).toHaveBeenCalledTimes(1);
+            expect(prisma.findMany).toHaveBeenCalledWith({ ...sortOptions, ...expectedWhere });
+            expect(res).toEqual([testPlayer]);
+        });
+    });
+});

--- a/tests/unit/DAO/v2/PlayerDAO.test.ts
+++ b/tests/unit/DAO/v2/PlayerDAO.test.ts
@@ -50,7 +50,7 @@ describe("[PRISMA] PlayerDAO", () => {
         it("should return pass in an array of WHERE AND objects if multiple input params are given", async () => {
             prisma.findMany.mockResolvedValueOnce([testPlayer]);
             const sortOptions = { orderBy: { id: "asc" } };
-            const expectedWhere = { where: { AND: [{ mlbTeam: "LAD"}, {name: "Joseph" }] } };
+            const expectedWhere = { where: { AND: [{ mlbTeam: "LAD" }, { name: "Joseph" }] } };
             const inputParam = ["mlbTeam.LAD", "name.Joseph"];
 
             const res = await Players.findPlayers(inputParam);

--- a/tests/unit/DAO/v2/PlayerDAO.test.ts
+++ b/tests/unit/DAO/v2/PlayerDAO.test.ts
@@ -50,7 +50,7 @@ describe("[PRISMA] PlayerDAO", () => {
         it("should return pass in an array of WHERE AND objects if multiple input params are given", async () => {
             prisma.findMany.mockResolvedValueOnce([testPlayer]);
             const sortOptions = { orderBy: { id: "asc" } };
-            const expectedWhere = { where: { AND: [{ mlbTeam: "LAD", name: "Joseph" }] } };
+            const expectedWhere = { where: { AND: [{ mlbTeam: "LAD"}, {name: "Joseph" }] } };
             const inputParam = ["mlbTeam.LAD", "name.Joseph"];
 
             const res = await Players.findPlayers(inputParam);

--- a/tests/unit/api/routes/PlayerController.test.ts
+++ b/tests/unit/api/routes/PlayerController.test.ts
@@ -61,10 +61,7 @@ describe("PlayerController", () => {
 
             expect(mockPlayerDAO.getAllPlayers).toHaveBeenCalledTimes(0);
             expect(mockPlayerDAO.findPlayers).toHaveBeenCalledTimes(1);
-            expect(mockPlayerDAO.findPlayers).toHaveBeenCalledWith([
-                { league: PlayerLeagueType.MINOR },
-                { league: PlayerLeagueType.MAJOR },
-            ]);
+            expect(mockPlayerDAO.findPlayers.mock.calls[0][0].league).toMatchObject({"_multipleParameters": true, "_type": "in", "_value": [2, 1]});
             expect(res).toEqual([testPlayer]);
         });
         it("should bubble up any errors from the DAO", async () => {

--- a/tests/unit/api/routes/PlayerController.test.ts
+++ b/tests/unit/api/routes/PlayerController.test.ts
@@ -61,7 +61,11 @@ describe("PlayerController", () => {
 
             expect(mockPlayerDAO.getAllPlayers).toHaveBeenCalledTimes(0);
             expect(mockPlayerDAO.findPlayers).toHaveBeenCalledTimes(1);
-            expect(mockPlayerDAO.findPlayers.mock.calls[0][0].league).toMatchObject({"_multipleParameters": true, "_type": "in", "_value": [2, 1]});
+            expect(mockPlayerDAO.findPlayers.mock.calls[0][0].league).toMatchObject({
+                _multipleParameters: true,
+                _type: "in",
+                _value: [2, 1],
+            });
             expect(res).toEqual([testPlayer]);
         });
         it("should bubble up any errors from the DAO", async () => {

--- a/tests/unit/api/routes/v2/PlayerController.test.ts
+++ b/tests/unit/api/routes/v2/PlayerController.test.ts
@@ -1,0 +1,43 @@
+import { PlayerFactory } from "../../../../factories/PlayerFactory";
+import { Player } from "@prisma/client";
+import PlayerDAO from "../../../../../src/DAO/v2/PlayerDAO";
+import { mockDeep, mockClear } from "jest-mock-extended";
+import PlayerController from "../../../../../src/api/routes/v2/PlayerController";
+import logger from "../../../../../src/bootstrap/logger";
+
+describe("[V2] PlayerController", () => {
+    const testPlayer: Player = PlayerFactory.getPrismaPlayer();
+    const Players = mockDeep<PlayerDAO>();
+    const playerController = new PlayerController(Players);
+
+    afterEach(() => {
+        mockClear(Players);
+    });
+    beforeAll(() => {
+        logger.debug("~~~~~~PRISMA PLAYER CONTROLLER TESTS BEGIN~~~~~~");
+    });
+    afterAll(() => {
+        logger.debug("~~~~~~PRISMA PLAYER CONTROLLER TESTS COMPLETE~~~~~~");
+    });
+
+    describe("getAll()", () => {
+        it("should return an array of all players in the db", async () => {
+            Players.getAllPlayers.mockResolvedValueOnce([testPlayer]);
+
+            const res = await playerController.getAll();
+
+            expect(Players.getAllPlayers).toHaveBeenCalledTimes(1);
+            expect(Players.getAllPlayers).toHaveBeenCalledWith();
+            expect(res).toEqual([testPlayer]);
+        });
+        it("should return an array of filtered players when called with some 'where' params", async () => {
+            Players.findPlayers.mockResolvedValueOnce([testPlayer]);
+
+            const res = await playerController.getAll(["mlbTeam.LAD", "name.Akosua"]);
+
+            expect(Players.findPlayers).toHaveBeenCalledTimes(1);
+            expect(Players.findPlayers).toHaveBeenCalledWith(["mlbTeam.LAD", "name.Akosua"]);
+            expect(res).toEqual([testPlayer]);
+        });
+    });
+});


### PR DESCRIPTION
Nick reported a bug where he couldn't add minor league players to any trade.

Logs show this error message:
```json
{
  "level": "error",
  "message": "Handling error: EntityPropertyNotFoundError: Property \"0\" was not found in \"Player\". Make sure your query is correct.\n    at SelectQueryBuilder.buildWhere (/opt/Apps/TradeMachine/src/query-builder/SelectQueryBuilder.ts:4026:27)\n    at SelectQueryBuilder.applyFindOptions (/opt/Apps/TradeMachine/src/query-builder/SelectQueryBuilder.ts:2981:40)\n    at SelectQueryBuilder.setFindOptions (/opt/Apps/TradeMachine/src/query-builder/SelectQueryBuilder.ts:103:14)\n    at EntityManager.find (/opt/Apps/TradeMachine/src/entity-manager/EntityManager.ts:994:14)\n    at Repository.find (/opt/Apps/TradeMachine/src/repository/Repository.ts:476:29)\n    at PlayerDAO.findPlayers (/opt/Apps/TradeMachine/src/DAO/PlayerDAO.ts:56:36)\n    at PlayerController.getAllPlayers (/opt/Apps/TradeMachine/src/api/routes/PlayerController.ts:45:39)\n    at ActionMetadata.callMethod (/opt/Apps/TradeMachine/node_modules/src/metadata/ActionMetadata.ts:252:44)\n    at /opt/Apps/TradeMachine/node_modules/src/RoutingControllers.ts:123:28\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)",
  "timestamp": "2023-01-08 04:10:02 PM"
}
```

Basically at some point we changed the code that takes the API's `includes[]=majors&includes[]=minors` parameter, and passes it to the DAO to be used in the find query. But we were passing it as an array of objects (eg: `[{league: majors}, {league: minors}]` when the find was expecting just a single object. 

I did fix the existing API but I also just decided to go ahead and create a v2, prsima-based api for this endpoint now and will switch the client over to that so that we make some progress on our migration off of TypeORM