### PR TITLE
temporarily turn off caching to unblock deploy

### DIFF
--- a/.github/workflows/docker-build-and-deploy.yml
+++ b/.github/workflows/docker-build-and-deploy.yml
@@ -134,10 +134,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |
-            type=gha
             type=registry,ref=ghcr.io/akosasante/trade-machine-server:cache
           cache-to: |
-            type=gha,mode=max
             type=registry,ref=ghcr.io/akosasante/trade-machine-server:cache,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1


### PR DESCRIPTION
This pull request makes a small update to the Docker build and deploy GitHub Actions workflow. The change removes the use of GitHub Actions cache (`type=gha`) for Docker builds, so only the registry-based cache is now used for both `cache-from` and `cache-to` settings.