### PR TITLE
feat(discord): enqueue Oban jobs for trade action DMs

### DIFF
--- a/src/DAO/v2/ObanDAO.ts
+++ b/src/DAO/v2/ObanDAO.ts
@@ -56,12 +56,50 @@ export interface TradeSubmitJobData {
 // Union of all jobs handled by TradeMachine.Jobs.EmailWorker
 export type EmailJobData = UserEmailJobData | TradeRequestJobData | TradeDeclinedJobData | TradeSubmitJobData;
 
-export interface DiscordJobData {
+export interface DiscordTradeAnnouncementJobData {
     env: ObanEnv;
     job_type: "trade_announcement";
     data: string; // trade ID
     trace_context?: TraceContext;
 }
+
+export interface DiscordTradeRequestDmJobData {
+    env: ObanEnv;
+    job_type: "trade_request_dm";
+    trade_id: string;
+    recipient_user_id: string;
+    user_id?: string;
+    accept_url: string;
+    decline_url: string;
+    trace_context?: TraceContext;
+}
+
+export interface DiscordTradeSubmitDmJobData {
+    env: ObanEnv;
+    job_type: "trade_submit_dm";
+    trade_id: string;
+    recipient_user_id: string;
+    user_id?: string;
+    submit_url: string;
+    trace_context?: TraceContext;
+}
+
+export interface DiscordTradeDeclinedDmJobData {
+    env: ObanEnv;
+    job_type: "trade_declined_dm";
+    trade_id: string;
+    recipient_user_id: string;
+    user_id?: string;
+    is_creator: boolean;
+    decline_url?: string;
+    trace_context?: TraceContext;
+}
+
+export type DiscordJobData =
+    | DiscordTradeAnnouncementJobData
+    | DiscordTradeRequestDmJobData
+    | DiscordTradeSubmitDmJobData
+    | DiscordTradeDeclinedDmJobData;
 
 export interface WebhookStatusJobData {
     env: ObanEnv;
@@ -252,6 +290,70 @@ export default class ObanDAO {
             env: (process.env.APP_ENV as ObanEnv) || "staging",
             job_type: "trade_announcement",
             data: tradeId,
+            trace_context: traceContext,
+        });
+    }
+
+    /**
+     * Enqueue a Discord DM for a trade request (accept/decline links).
+     */
+    public async enqueueTradeRequestDm(
+        tradeId: string,
+        recipientUserId: string,
+        acceptUrl: string,
+        declineUrl: string,
+        traceContext?: TraceContext
+    ): Promise<ObanJob> {
+        return this.enqueueDiscordJob({
+            env: (process.env.APP_ENV as ObanEnv) || "staging",
+            job_type: "trade_request_dm",
+            trade_id: tradeId,
+            recipient_user_id: recipientUserId,
+            user_id: recipientUserId,
+            accept_url: acceptUrl,
+            decline_url: declineUrl,
+            trace_context: traceContext,
+        });
+    }
+
+    /**
+     * Enqueue a Discord DM prompting the creator to submit an accepted trade.
+     */
+    public async enqueueTradeSubmitDm(
+        tradeId: string,
+        recipientUserId: string,
+        submitUrl: string,
+        traceContext?: TraceContext
+    ): Promise<ObanJob> {
+        return this.enqueueDiscordJob({
+            env: (process.env.APP_ENV as ObanEnv) || "staging",
+            job_type: "trade_submit_dm",
+            trade_id: tradeId,
+            recipient_user_id: recipientUserId,
+            user_id: recipientUserId,
+            submit_url: submitUrl,
+            trace_context: traceContext,
+        });
+    }
+
+    /**
+     * Enqueue a Discord DM when a trade was declined (FYI to other participants).
+     */
+    public async enqueueTradeDeclinedDm(
+        tradeId: string,
+        recipientUserId: string,
+        isCreator: boolean,
+        declineUrl: string | undefined,
+        traceContext?: TraceContext
+    ): Promise<ObanJob> {
+        return this.enqueueDiscordJob({
+            env: (process.env.APP_ENV as ObanEnv) || "staging",
+            job_type: "trade_declined_dm",
+            trade_id: tradeId,
+            recipient_user_id: recipientUserId,
+            user_id: recipientUserId,
+            is_creator: isCreator,
+            decline_url: declineUrl,
             trace_context: traceContext,
         });
     }

--- a/src/api/routes/MessengerController.ts
+++ b/src/api/routes/MessengerController.ts
@@ -13,6 +13,8 @@ import { extractTraceContext } from "../../utils/tracing";
 import { createTradeActionToken } from "./v2/utils/tradeActionTokens";
 import { tradeActionTokenGeneratedMetric, tradeRequestEmailEnqueuedMetric } from "../../bootstrap/metrics";
 import { shouldUseV3TradeLinkForEmail } from "../../utils/v3TradeLinkEmailAllowlist";
+import { mapOwnerIdsToDiscordUserIds } from "../../utils/discordTradeDmPrisma";
+import type { ExtendedPrismaClient } from "../../bootstrap/prisma-db";
 
 const TRADE_REQUEST_OWNER_RELATIONS = ["tradeParticipants", "tradeParticipants.team", "tradeParticipants.team.owners"];
 
@@ -45,10 +47,10 @@ export default class MessengerController {
             throw new BadRequestError("Cannot send trade request for this trade based on its status");
         }
 
+        const prisma = getPrismaClientFromRequest(request);
         const obanDao =
             this.obanDao ??
             (() => {
-                const prisma = getPrismaClientFromRequest(request);
                 return prisma ? new ObanDAO(prisma.obanJob) : null;
             })();
 
@@ -63,14 +65,17 @@ export default class MessengerController {
         const v3BaseDomain = process.env.V3_BASE_URL;
 
         const recipientOwners = trade.recipients.flatMap(recipTeam => recipTeam.owners ?? []);
+        const discordByOwner = prisma
+            ? await mapOwnerIdsToDiscordUserIds(prisma as ExtendedPrismaClient, recipientOwners.map(o => o.id))
+            : new Map<string, string>();
 
         for (const owner of recipientOwners) {
-            if (!owner.email) continue;
+            if (!owner?.id) continue;
 
             let acceptUrl: string;
             let declineUrl: string;
 
-            if (shouldUseV3TradeLinkForEmail(owner.email) && v3BaseDomain && trade.id && owner.id) {
+            if (shouldUseV3TradeLinkForEmail(owner.email) && v3BaseDomain && trade.id) {
                 const [acceptToken, declineToken] = await Promise.all([
                     createTradeActionToken({ userId: owner.id, tradeId: trade.id, action: "accept" }),
                     createTradeActionToken({ userId: owner.id, tradeId: trade.id, action: "decline" }),
@@ -85,9 +90,16 @@ export default class MessengerController {
                 declineUrl = `${baseDomain}/trade/${trade.id}/reject`;
             }
 
-            await obanDao.enqueueTradeRequestEmail(trade.id!, owner.id!, acceptUrl, declineUrl, traceContext);
-            tradeRequestEmailEnqueuedMetric.inc();
-            logger.debug(`[sendRequestTradeMessage] Enqueued trade request email for userId=${owner.id}`);
+            if (owner.email) {
+                await obanDao.enqueueTradeRequestEmail(trade.id!, owner.id!, acceptUrl, declineUrl, traceContext);
+                tradeRequestEmailEnqueuedMetric.inc();
+                logger.debug(`[sendRequestTradeMessage] Enqueued trade request email for userId=${owner.id}`);
+            }
+
+            if (discordByOwner.has(owner.id)) {
+                await obanDao.enqueueTradeRequestDm(trade.id!, owner.id, acceptUrl, declineUrl, traceContext);
+                logger.debug(`[sendRequestTradeMessage] Enqueued trade request Discord DM job for userId=${owner.id}`);
+            }
         }
 
         return response.status(202).json({ status: "trade request queued" });
@@ -105,10 +117,10 @@ export default class MessengerController {
         if (trade.status === TradeStatus.REJECTED && trade.declinedById) {
             trade = await this.tradeDao.hydrateTrade(trade);
 
+            const prisma = getPrismaClientFromRequest(request);
             const obanDao =
                 this.obanDao ??
                 (() => {
-                    const prisma = getPrismaClientFromRequest(request);
                     return prisma ? new ObanDAO(prisma.obanJob) : null;
                 })();
 
@@ -127,6 +139,10 @@ export default class MessengerController {
                     ?.flatMap(tp => tp.team.owners)
                     .filter(owner => owner && owner.id !== trade.declinedById) ?? [];
 
+            const discordByOwner = prisma
+                ? await mapOwnerIdsToDiscordUserIds(prisma as ExtendedPrismaClient, eligibleOwners.map(o => o?.id))
+                : new Map<string, string>();
+
             for (const owner of eligibleOwners) {
                 if (!owner?.id) continue;
                 const isCreator = creatorOwnerIds.has(owner.id);
@@ -143,10 +159,19 @@ export default class MessengerController {
                     logger.debug(`[sendTradeDeclineMessage] Using V3 view-token URL for userId=${owner.id}`);
                 }
 
-                await obanDao.enqueueTradeDeclinedEmail(trade.id!, owner.id, isCreator, declineUrl, traceContext);
-                logger.debug(
-                    `[sendTradeDeclineMessage] Enqueued trade declined email for userId=${owner.id}, isCreator=${isCreator}`
-                );
+                if (owner.email) {
+                    await obanDao.enqueueTradeDeclinedEmail(trade.id!, owner.id, isCreator, declineUrl, traceContext);
+                    logger.debug(
+                        `[sendTradeDeclineMessage] Enqueued trade declined email for userId=${owner.id}, isCreator=${isCreator}`
+                    );
+                }
+
+                if (discordByOwner.has(owner.id)) {
+                    await obanDao.enqueueTradeDeclinedDm(trade.id!, owner.id, isCreator, declineUrl, traceContext);
+                    logger.debug(
+                        `[sendTradeDeclineMessage] Enqueued trade declined Discord DM job for userId=${owner.id}, isCreator=${isCreator}`
+                    );
+                }
             }
 
             return response.status(202).json({ status: "trade decline email queued" });
@@ -167,10 +192,10 @@ export default class MessengerController {
         if (trade.status === TradeStatus.ACCEPTED) {
             trade = await this.tradeDao.hydrateTrade(trade);
 
+            const prisma = getPrismaClientFromRequest(request);
             const obanDao =
                 this.obanDao ??
                 (() => {
-                    const prisma = getPrismaClientFromRequest(request);
                     return prisma ? new ObanDAO(prisma.obanJob) : null;
                 })();
 
@@ -185,6 +210,10 @@ export default class MessengerController {
             const v3BaseDomain = process.env.V3_BASE_URL;
 
             const creatorOwners = trade.creator?.owners ?? [];
+            const discordByOwner = prisma
+                ? await mapOwnerIdsToDiscordUserIds(prisma as ExtendedPrismaClient, creatorOwners.map(o => o?.id))
+                : new Map<string, string>();
+
             for (const owner of creatorOwners) {
                 if (!owner?.id) continue;
 
@@ -202,8 +231,15 @@ export default class MessengerController {
                     submitUrl = `${baseDomain}/trade/${trade.id}/submit`;
                 }
 
-                await obanDao.enqueueTradeSubmitEmail(trade.id!, owner.id, submitUrl, traceContext);
-                logger.debug(`[sendTradeAcceptanceMessage] Enqueued trade submit email for userId=${owner.id}`);
+                if (owner.email) {
+                    await obanDao.enqueueTradeSubmitEmail(trade.id!, owner.id, submitUrl, traceContext);
+                    logger.debug(`[sendTradeAcceptanceMessage] Enqueued trade submit email for userId=${owner.id}`);
+                }
+
+                if (discordByOwner.has(owner.id)) {
+                    await obanDao.enqueueTradeSubmitDm(trade.id!, owner.id, submitUrl, traceContext);
+                    logger.debug(`[sendTradeAcceptanceMessage] Enqueued trade submit Discord DM job for userId=${owner.id}`);
+                }
             }
 
             return response.status(202).json({ status: "trade acceptance email queued" });

--- a/src/api/routes/MessengerController.ts
+++ b/src/api/routes/MessengerController.ts
@@ -14,7 +14,6 @@ import { createTradeActionToken } from "./v2/utils/tradeActionTokens";
 import { tradeActionTokenGeneratedMetric, tradeRequestEmailEnqueuedMetric } from "../../bootstrap/metrics";
 import { shouldUseV3TradeLinkForEmail } from "../../utils/v3TradeLinkEmailAllowlist";
 import { mapOwnerIdsToDiscordUserIds } from "../../utils/discordTradeDmPrisma";
-import type { ExtendedPrismaClient } from "../../bootstrap/prisma-db";
 
 const TRADE_REQUEST_OWNER_RELATIONS = ["tradeParticipants", "tradeParticipants.team", "tradeParticipants.team.owners"];
 
@@ -66,7 +65,10 @@ export default class MessengerController {
 
         const recipientOwners = trade.recipients.flatMap(recipTeam => recipTeam.owners ?? []);
         const discordByOwner = prisma
-            ? await mapOwnerIdsToDiscordUserIds(prisma as ExtendedPrismaClient, recipientOwners.map(o => o.id))
+            ? await mapOwnerIdsToDiscordUserIds(
+                  prisma,
+                  recipientOwners.map(o => o.id)
+              )
             : new Map<string, string>();
 
         for (const owner of recipientOwners) {
@@ -91,7 +93,7 @@ export default class MessengerController {
             }
 
             if (owner.email) {
-                await obanDao.enqueueTradeRequestEmail(trade.id!, owner.id!, acceptUrl, declineUrl, traceContext);
+                await obanDao.enqueueTradeRequestEmail(trade.id!, owner.id, acceptUrl, declineUrl, traceContext);
                 tradeRequestEmailEnqueuedMetric.inc();
                 logger.debug(`[sendRequestTradeMessage] Enqueued trade request email for userId=${owner.id}`);
             }
@@ -140,7 +142,10 @@ export default class MessengerController {
                     .filter(owner => owner && owner.id !== trade.declinedById) ?? [];
 
             const discordByOwner = prisma
-                ? await mapOwnerIdsToDiscordUserIds(prisma as ExtendedPrismaClient, eligibleOwners.map(o => o?.id))
+                ? await mapOwnerIdsToDiscordUserIds(
+                      prisma,
+                      eligibleOwners.map(o => o?.id)
+                  )
                 : new Map<string, string>();
 
             for (const owner of eligibleOwners) {
@@ -211,7 +216,10 @@ export default class MessengerController {
 
             const creatorOwners = trade.creator?.owners ?? [];
             const discordByOwner = prisma
-                ? await mapOwnerIdsToDiscordUserIds(prisma as ExtendedPrismaClient, creatorOwners.map(o => o?.id))
+                ? await mapOwnerIdsToDiscordUserIds(
+                      prisma,
+                      creatorOwners.map(o => o?.id)
+                  )
                 : new Map<string, string>();
 
             for (const owner of creatorOwners) {
@@ -238,7 +246,9 @@ export default class MessengerController {
 
                 if (discordByOwner.has(owner.id)) {
                     await obanDao.enqueueTradeSubmitDm(trade.id!, owner.id, submitUrl, traceContext);
-                    logger.debug(`[sendTradeAcceptanceMessage] Enqueued trade submit Discord DM job for userId=${owner.id}`);
+                    logger.debug(
+                        `[sendTradeAcceptanceMessage] Enqueued trade submit Discord DM job for userId=${owner.id}`
+                    );
                 }
             }
 

--- a/src/api/routes/v2/routers/trade.ts
+++ b/src/api/routes/v2/routers/trade.ts
@@ -122,7 +122,11 @@ function allRecipientTeamsAccepted(acceptedBy: string[], trade: PrismaTrade): bo
 
 // ─── Notification helpers ─────────────────────────────────────────────────────
 
-async function enqueueAcceptanceNotifications(tradeId: string, trade: PrismaTrade, prisma: ExtendedPrismaClient): Promise<void> {
+async function enqueueAcceptanceNotifications(
+    tradeId: string,
+    trade: PrismaTrade,
+    prisma: ExtendedPrismaClient
+): Promise<void> {
     const obanDao = new ObanDAO(prisma.obanJob);
     const v3BaseDomain = process.env.V3_BASE_URL;
 

--- a/src/api/routes/v2/routers/trade.ts
+++ b/src/api/routes/v2/routers/trade.ts
@@ -9,6 +9,7 @@ import TradeDAO, { AcceptedByEntry, PrismaTrade } from "../../../../DAO/v2/Trade
 import ObanDAO from "../../../../DAO/v2/ObanDAO";
 import { createTradeActionToken } from "../utils/tradeActionTokens";
 import { shouldUseV3TradeLinkForEmail } from "../../../../utils/v3TradeLinkEmailAllowlist";
+import { mapOwnerIdsToDiscordUserIds } from "../../../../utils/discordTradeDmPrisma";
 import { PublicUser } from "../../../../DAO/v2/UserDAO";
 import type { ExtendedPrismaClient } from "../../../../bootstrap/prisma-db";
 
@@ -121,18 +122,19 @@ function allRecipientTeamsAccepted(acceptedBy: string[], trade: PrismaTrade): bo
 
 // ─── Notification helpers ─────────────────────────────────────────────────────
 
-async function enqueueAcceptanceNotifications(
-    tradeId: string,
-    trade: PrismaTrade,
-    obanDb: ExtendedPrismaClient["obanJob"]
-): Promise<void> {
-    const obanDao = new ObanDAO(obanDb);
+async function enqueueAcceptanceNotifications(tradeId: string, trade: PrismaTrade, prisma: ExtendedPrismaClient): Promise<void> {
+    const obanDao = new ObanDAO(prisma.obanJob);
     const v3BaseDomain = process.env.V3_BASE_URL;
 
     const creatorOwners = trade.tradeParticipants
         .filter(p => p.participantType === TradeParticipantType.CREATOR)
         .flatMap(p => p.team?.owners ?? [])
         .filter((o): o is NonNullable<typeof o> => !!o?.id);
+
+    const discordByOwner = await mapOwnerIdsToDiscordUserIds(
+        prisma,
+        creatorOwners.map(o => o.id)
+    );
 
     for (const owner of creatorOwners) {
         let submitUrl: string;
@@ -148,8 +150,15 @@ async function enqueueAcceptanceNotifications(
             submitUrl = `${process.env.BASE_URL ?? ""}/trade/${tradeId}/submit`;
         }
 
-        await obanDao.enqueueTradeSubmitEmail(tradeId, owner.id, submitUrl);
-        logger.info(`[trades.accept] Enqueued submit-prompt email userId=${owner.id} tradeId=${tradeId}`);
+        if (owner.email) {
+            await obanDao.enqueueTradeSubmitEmail(tradeId, owner.id, submitUrl);
+            logger.info(`[trades.accept] Enqueued submit-prompt email userId=${owner.id} tradeId=${tradeId}`);
+        }
+
+        if (discordByOwner.has(owner.id)) {
+            await obanDao.enqueueTradeSubmitDm(tradeId, owner.id, submitUrl);
+            logger.info(`[trades.accept] Enqueued submit-prompt Discord DM userId=${owner.id} tradeId=${tradeId}`);
+        }
     }
 }
 
@@ -157,9 +166,9 @@ async function enqueueDeclineNotifications(
     tradeId: string,
     decliningUserId: string,
     trade: PrismaTrade,
-    obanDb: ExtendedPrismaClient["obanJob"]
+    prisma: ExtendedPrismaClient
 ): Promise<void> {
-    const obanDao = new ObanDAO(obanDb);
+    const obanDao = new ObanDAO(prisma.obanJob);
     const v3BaseDomain = process.env.V3_BASE_URL;
 
     const creatorOwnerIdSet = new Set(
@@ -172,6 +181,11 @@ async function enqueueDeclineNotifications(
     const eligibleOwners = trade.tradeParticipants
         .flatMap(p => p.team?.owners ?? [])
         .filter((o): o is NonNullable<typeof o> => !!o?.id && o.id !== decliningUserId);
+
+    const discordByOwner = await mapOwnerIdsToDiscordUserIds(
+        prisma,
+        eligibleOwners.map(o => o.id)
+    );
 
     for (const owner of eligibleOwners) {
         const isCreator = creatorOwnerIdSet.has(owner.id);
@@ -187,10 +201,19 @@ async function enqueueDeclineNotifications(
             declineUrl = `${v3BaseDomain}/trades/${tradeId}?token=${viewToken}`;
         }
 
-        await obanDao.enqueueTradeDeclinedEmail(tradeId, owner.id, isCreator, declineUrl);
-        logger.info(
-            `[trades.decline] Enqueued decline email userId=${owner.id} tradeId=${tradeId} isCreator=${isCreator}`
-        );
+        if (owner.email) {
+            await obanDao.enqueueTradeDeclinedEmail(tradeId, owner.id, isCreator, declineUrl);
+            logger.info(
+                `[trades.decline] Enqueued decline email userId=${owner.id} tradeId=${tradeId} isCreator=${isCreator}`
+            );
+        }
+
+        if (discordByOwner.has(owner.id)) {
+            await obanDao.enqueueTradeDeclinedDm(tradeId, owner.id, isCreator, declineUrl);
+            logger.info(
+                `[trades.decline] Enqueued decline Discord DM userId=${owner.id} tradeId=${tradeId} isCreator=${isCreator}`
+            );
+        }
     }
 }
 
@@ -357,7 +380,7 @@ export const tradeRouter = router({
 
             if (allAccepted && !input.skipNotifications) {
                 addSpanEvent("trades.accept.all_accepted");
-                await enqueueAcceptanceNotifications(input.tradeId, trade, ctx.prisma.obanJob);
+                await enqueueAcceptanceNotifications(input.tradeId, trade, ctx.prisma);
             }
 
             addSpanEvent("trades.accept.success");
@@ -411,7 +434,7 @@ export const tradeRouter = router({
                 const updatedTrade = await dao.updateDeclinedBy(input.tradeId, effectiveUserId, input.declinedReason);
 
                 if (!input.skipNotifications) {
-                    await enqueueDeclineNotifications(input.tradeId, effectiveUserId, trade, ctx.prisma.obanJob);
+                    await enqueueDeclineNotifications(input.tradeId, effectiveUserId, trade, ctx.prisma);
                 }
 
                 addSpanEvent("trades.decline.success");

--- a/src/utils/discordTradeDmPrisma.ts
+++ b/src/utils/discordTradeDmPrisma.ts
@@ -1,0 +1,26 @@
+import { ExtendedPrismaClient } from "../bootstrap/prisma-db";
+
+/**
+ * Returns owner id -> trimmed discordUserId for owners that have Discord linked.
+ */
+export async function mapOwnerIdsToDiscordUserIds(
+    prisma: ExtendedPrismaClient,
+    ownerIds: (string | undefined | null)[]
+): Promise<Map<string, string>> {
+    const unique = [...new Set(ownerIds.filter((id): id is string => typeof id === "string" && id.length > 0))];
+    if (unique.length === 0) {
+        return new Map();
+    }
+    const rows = await prisma.user.findMany({
+        where: { id: { in: unique } },
+        select: { id: true, discordUserId: true },
+    });
+    const m = new Map<string, string>();
+    for (const r of rows) {
+        const d = r.discordUserId?.trim();
+        if (d) {
+            m.set(r.id, d);
+        }
+    }
+    return m;
+}

--- a/src/utils/discordTradeDmPrisma.ts
+++ b/src/utils/discordTradeDmPrisma.ts
@@ -11,10 +11,11 @@ export async function mapOwnerIdsToDiscordUserIds(
     if (unique.length === 0) {
         return new Map();
     }
-    const rows = await prisma.user.findMany({
+    const rowsRaw = await prisma.user.findMany({
         where: { id: { in: unique } },
         select: { id: true, discordUserId: true },
     });
+    const rows = Array.isArray(rowsRaw) ? rowsRaw : [];
     const m = new Map<string, string>();
     for (const r of rows) {
         const d = r.discordUserId?.trim();

--- a/tests/integration/MessengerRoutes.test.ts
+++ b/tests/integration/MessengerRoutes.test.ts
@@ -110,6 +110,29 @@ describe("Messenger API endpoints", () => {
 
             expect(body.status).toBe("trade request queued");
         }, 2000);
+
+        it("should enqueue trade_request_dm Oban job when a recipient owner has discordUserId", async () => {
+            await prismaConn.user.update({
+                where: { id: ownerUser.id! },
+                data: { discordUserId: "123456789012345678" },
+            });
+            const requestedTrade = await createTradeOfStatus(TradeStatus.REQUESTED);
+
+            const { body } = await adminLoggedIn(req(requestedTrade.id!), app);
+            expect(body.status).toBe("trade request queued");
+
+            const dmJobs = await prismaConn.obanJob.findMany({
+                where: { worker: "TradeMachine.Jobs.DiscordWorker", queue: "discord" },
+                orderBy: { id: "desc" },
+                take: 30,
+            });
+            const match = dmJobs.filter(j => {
+                const args = j.args as { job_type?: string; trade_id?: string };
+                return args.job_type === "trade_request_dm" && args.trade_id === requestedTrade.id;
+            });
+            expect(match.length).toBeGreaterThanOrEqual(1);
+        });
+
         it("should return a 400 Bad Request if the trade status is not REQUESTED", async () => {
             const draftTrade = await createTradeOfStatus(TradeStatus.DRAFT);
 
@@ -164,6 +187,32 @@ describe("Messenger API endpoints", () => {
             expect(body.status).toBe("trade decline email queued");
             expect(obanCountAfter).toBeGreaterThan(obanCountBefore);
         });
+
+        it("should enqueue trade_declined_dm Oban job for an eligible owner with discordUserId", async () => {
+            await prismaConn.user.update({
+                where: { id: adminUser.id! },
+                data: { discordUserId: "111222333444555666" },
+            });
+            const declinedTrade = await createTradeOfStatus(TradeStatus.REJECTED, {
+                declinedById: ownerUser.id,
+                declinedReason: "integration test",
+            });
+
+            const { body } = await adminLoggedIn(req(declinedTrade.id!), app);
+            expect(body.status).toBe("trade decline email queued");
+
+            const dmJobs = await prismaConn.obanJob.findMany({
+                where: { worker: "TradeMachine.Jobs.DiscordWorker", queue: "discord" },
+                orderBy: { id: "desc" },
+                take: 30,
+            });
+            const match = dmJobs.filter(j => {
+                const args = j.args as { job_type?: string; trade_id?: string };
+                return args.job_type === "trade_declined_dm" && args.trade_id === declinedTrade.id;
+            });
+            expect(match.length).toBeGreaterThanOrEqual(1);
+        });
+
         it("should enqueue a trade declined email job via Oban successfully if logged in as an owner", async () => {
             const declinedTrade = await createTradeOfStatus(TradeStatus.REJECTED, {
                 declinedById: ownerUser.id,
@@ -308,6 +357,29 @@ describe("Messenger API endpoints", () => {
             expect(body.status).toBe("trade acceptance email queued");
             expect(obanCountAfter).toBeGreaterThan(obanCountBefore);
         });
+
+        it("should enqueue trade_submit_dm Oban job when a creator owner has discordUserId", async () => {
+            await prismaConn.user.update({
+                where: { id: adminUser.id! },
+                data: { discordUserId: "987654321098765432" },
+            });
+            const acceptedTrade = await createTradeOfStatus(TradeStatus.ACCEPTED);
+
+            const { body } = await adminLoggedIn(req(acceptedTrade.id!), app);
+            expect(body.status).toBe("trade acceptance email queued");
+
+            const dmJobs = await prismaConn.obanJob.findMany({
+                where: { worker: "TradeMachine.Jobs.DiscordWorker", queue: "discord" },
+                orderBy: { id: "desc" },
+                take: 30,
+            });
+            const match = dmJobs.filter(j => {
+                const args = j.args as { job_type?: string; trade_id?: string };
+                return args.job_type === "trade_submit_dm" && args.trade_id === acceptedTrade.id;
+            });
+            expect(match.length).toBeGreaterThanOrEqual(1);
+        });
+
         it("should enqueue a trade acceptance job via Oban successfully if logged in as an owner", async () => {
             const acceptedTrade = await createTradeOfStatus(TradeStatus.ACCEPTED);
 

--- a/tests/unit/DAO/v2/ObanDAO.test.ts
+++ b/tests/unit/DAO/v2/ObanDAO.test.ts
@@ -343,4 +343,84 @@ describe("ObanDAO Unit Tests", () => {
             });
         });
     });
+
+    describe("enqueueTradeRequestDm", () => {
+        it("should enqueue trade_request_dm on discord queue", async () => {
+            process.env.APP_ENV = "staging";
+            const mockJob = { id: BigInt(30), state: oban_job_state.available };
+            mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
+
+            await obanDao.enqueueTradeRequestDm(
+                "t1",
+                "u1",
+                "https://app/trades/t1?action=accept&token=a",
+                "https://app/trades/t1?action=decline&token=b"
+            );
+
+            expect(mockPrismaObanJob.create).toHaveBeenCalledWith({
+                data: expect.objectContaining({
+                    queue: "discord",
+                    worker: "TradeMachine.Jobs.DiscordWorker",
+                    args: expect.objectContaining({
+                        env: "staging",
+                        job_type: "trade_request_dm",
+                        trade_id: "t1",
+                        recipient_user_id: "u1",
+                        user_id: "u1",
+                        accept_url: "https://app/trades/t1?action=accept&token=a",
+                        decline_url: "https://app/trades/t1?action=decline&token=b",
+                    }),
+                }),
+            });
+        });
+    });
+
+    describe("enqueueTradeSubmitDm", () => {
+        it("should enqueue trade_submit_dm on discord queue", async () => {
+            process.env.APP_ENV = "production";
+            const mockJob = { id: BigInt(31), state: oban_job_state.available };
+            mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
+
+            await obanDao.enqueueTradeSubmitDm("t2", "u2", "https://app/trades/t2?action=submit&token=c");
+
+            expect(mockPrismaObanJob.create).toHaveBeenCalledWith({
+                data: expect.objectContaining({
+                    queue: "discord",
+                    worker: "TradeMachine.Jobs.DiscordWorker",
+                    args: expect.objectContaining({
+                        env: "production",
+                        job_type: "trade_submit_dm",
+                        trade_id: "t2",
+                        recipient_user_id: "u2",
+                        submit_url: "https://app/trades/t2?action=submit&token=c",
+                    }),
+                }),
+            });
+        });
+    });
+
+    describe("enqueueTradeDeclinedDm", () => {
+        it("should enqueue trade_declined_dm with optional decline_url", async () => {
+            process.env.APP_ENV = "development";
+            const mockJob = { id: BigInt(32), state: oban_job_state.available };
+            mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
+
+            await obanDao.enqueueTradeDeclinedDm("t3", "u3", true, "https://app/trades/t3?token=v");
+
+            expect(mockPrismaObanJob.create).toHaveBeenCalledWith({
+                data: expect.objectContaining({
+                    queue: "discord",
+                    worker: "TradeMachine.Jobs.DiscordWorker",
+                    args: expect.objectContaining({
+                        env: "development",
+                        job_type: "trade_declined_dm",
+                        trade_id: "t3",
+                        recipient_user_id: "u3",
+                        is_creator: true,
+                        decline_url: "https://app/trades/t3?token=v",
+                    }),
+                }),
+            });
+        });
+    });
 });

--- a/tests/unit/api/routes/MessengerController.test.ts
+++ b/tests/unit/api/routes/MessengerController.test.ts
@@ -34,6 +34,9 @@ describe("MessengerController", () => {
         enqueueTradeRequestEmail: jest.fn().mockResolvedValue({ id: BigInt(1) }),
         enqueueTradeDeclinedEmail: jest.fn().mockResolvedValue({ id: BigInt(2) }),
         enqueueTradeSubmitEmail: jest.fn().mockResolvedValue({ id: BigInt(3) }),
+        enqueueTradeRequestDm: jest.fn().mockResolvedValue({ id: BigInt(4) }),
+        enqueueTradeDeclinedDm: jest.fn().mockResolvedValue({ id: BigInt(5) }),
+        enqueueTradeSubmitDm: jest.fn().mockResolvedValue({ id: BigInt(6) }),
     };
     const mockRes = {
         status: jest.fn().mockReturnThis(),
@@ -106,6 +109,9 @@ describe("MessengerController", () => {
         mockObanDao.enqueueTradeRequestEmail.mockResolvedValue({ id: BigInt(1) });
         mockObanDao.enqueueTradeDeclinedEmail.mockResolvedValue({ id: BigInt(2) });
         mockObanDao.enqueueTradeSubmitEmail.mockResolvedValue({ id: BigInt(3) });
+        mockObanDao.enqueueTradeRequestDm.mockResolvedValue({ id: BigInt(4) });
+        mockObanDao.enqueueTradeDeclinedDm.mockResolvedValue({ id: BigInt(5) });
+        mockObanDao.enqueueTradeSubmitDm.mockResolvedValue({ id: BigInt(6) });
     });
 
     describe("sendRequestTradeMessage/2", () => {
@@ -131,6 +137,7 @@ describe("MessengerController", () => {
                 expect.stringContaining("/trade/"), // V2 decline URL
                 expect.anything() // trace context (may be undefined or an object in test env)
             );
+            expect(mockObanDao.enqueueTradeRequestDm).not.toHaveBeenCalled();
             expect(mockEmailPublisher.queueTradeRequestMail).not.toHaveBeenCalled();
 
             expect(mockRes.status).toHaveBeenCalledWith(202);
@@ -184,6 +191,7 @@ describe("MessengerController", () => {
                 expect.anything(),
                 expect.anything()
             );
+            expect(mockObanDao.enqueueTradeDeclinedDm).not.toHaveBeenCalled();
             expect(mockEmailPublisher.queueTradeDeclinedMail).not.toHaveBeenCalled();
 
             expect(mockRes.status).toHaveBeenCalledTimes(1);
@@ -271,6 +279,7 @@ describe("MessengerController", () => {
                     expect.anything()
                 );
             }
+            expect(mockObanDao.enqueueTradeSubmitDm).not.toHaveBeenCalled();
             expect(mockEmailPublisher.queueTradeAcceptedMail).not.toHaveBeenCalled();
 
             expect(mockRes.status).toHaveBeenCalledTimes(1);

--- a/tests/unit/api/routes/v2/trpc/trade.test.ts
+++ b/tests/unit/api/routes/v2/trpc/trade.test.ts
@@ -617,6 +617,7 @@ describe("[TRPC] Trades Router Unit Tests", () => {
             process.env.V3_TRADE_LINK_EMAIL_ALLOWLIST = "*";
             resetV3TradeLinkEmailAllowlistCacheForTests();
             mockPrisma.obanJob.create.mockResolvedValue({ id: BigInt(1) } as any);
+            mockPrisma.user.findMany.mockResolvedValue([] as any);
             mockCreateTradeActionToken.mockReset();
             mockCreateTradeActionToken.mockResolvedValue("mock-token-abc");
         });


### PR DESCRIPTION
## Summary
Enqueues Oban `DiscordWorker` jobs for trade request, submit, and decline flows (alongside email), using Prisma `discordUserId` lookups.

## Tests
- **Unit:** existing coverage + tRPC trade tests; `user.findMany` mock default for Discord ID mapping.
- **Integration:** `MessengerRoutes` asserts `oban_jobs` rows (`TradeMachine.Jobs.DiscordWorker`, `discord` queue, job_type + trade_id).

## Related
- **TradeMachineEx:** https://github.com/akosasante/TradeMachineEx/pull/28

## Deploy order
Ship **TradeMachineEx** with or before this server change.

## Local CI parity
- `make lint`, `npx prettier --check "src/**/*.ts" "tests/**/*.ts"`, `make typecheck`, `make test-ci-unit` — verified.
- `make test-ci-integration` matches GitHub Actions (`ORM_CONFIG=test`, Postgres on **5432**). For Docker on **5438**, use `ORM_CONFIG=local-test` and `PG_SCHEMA=test` per `ormconfig.js`.
