### PR TITLE
feat(notification-user-settings): add userSettings JSONB column + normalization + ADR

### DIFF
--- a/docs/adr/0001-user-settings-jsonb-on-user.md
+++ b/docs/adr/0001-user-settings-jsonb-on-user.md
@@ -1,0 +1,80 @@
+# ADR 0001: Store user settings as JSONB on the `user` table
+
+## Status
+
+Accepted
+
+## Context
+
+TradeMachine is adding per-user notification preferences (trade action Discord DMs, trade workflow emails). More user settings are expected in the short term beyond these two initial toggles.
+
+The existing `settings` table (`@@map("settings")` in Prisma) is league-wide (trade window / downtime) and should **not** be repurposed for per-user preferences.
+
+We need flexibility to add new settings keys without running a Prisma/Postgres migration each time.
+
+### Alternatives considered
+
+1. **Two boolean columns on `user`** — Strong DB types and constraints, but requires a migration per new setting; doesn't scale as the settings surface grows.
+2. **Separate `UserSettings` table (1:1) with JSONB** — Similar flexibility but adds a join and "does this row exist?" lifecycle management.
+3. **EAV table (`user_id`, `settings_key`, `settings_value`)** — Maximum flexibility but painful cross-field constraints, casting, and heavier queries; overkill for notification toggles.
+
+## Decision
+
+Add a single JSONB column `userSettings` on the `user` table (Prisma `Json` type, Postgres `jsonb`).
+
+### Document shape (schemaVersion 1)
+
+```json
+{
+  "schemaVersion": 1,
+  "settingsUpdatedAt": "2026-04-12T01:23:45.678Z",
+  "notifications": {
+    "tradeActionDiscordDm": true,
+    "tradeActionEmail": true
+  }
+}
+```
+
+### Key design rules
+
+1. **`schemaVersion`** (integer, starts at 1) — Writers set or preserve this on every update. Readers treat missing/null as 1. Future versions can branch normalization or reject unknown versions.
+
+2. **`settingsUpdatedAt`** (ISO 8601 UTC string) — Records when the settings blob last changed, inside the blob itself. Set by the server on every successful write. Independent of (but typically written together with) the `User` row's `dateModified`. Missing/null means "never saved via the settings API" — do **not** synthesize a timestamp.
+
+3. **Defaults live only in application code** — The DB column default is `'{}'::jsonb` (empty object); all interpretation happens through a shared `normalizeUserSettings()` function.
+
+4. **Asymmetric null/missing semantics** for the initial two notification toggles (explicit product choice):
+   - `notifications.tradeActionEmail`: absent or JSON null → **true** (emails stay on unless explicitly disabled).
+   - `notifications.tradeActionDiscordDm`: absent or JSON null → **false** (Discord DMs stay off until explicitly enabled).
+
+   Implication: empty `{}` or `{ "notifications": {} }` yields **email on, Discord off** — satisfies the "at least one channel on" invariant without a backfill of existing rows.
+
+5. **"At least one channel on" invariant** — Enforced **only in tRPC application code** (and V3 UI guardrails). No Postgres `CHECK` constraint for this pair in this phase. Direct SQL or future writers could store an illegal pair; this is an accepted tradeoff.
+
+6. **Dual implementation** — TypeScript (zod schema + `normalizeUserSettings()`) and Elixir (`normalize_user_settings/1`) both implement the same normalization rules. Keep them in sync manually for now; optionally add a shared JSON Schema document later.
+
+## Consequences
+
+### Positive
+
+- New settings keys can be added without a Prisma migration (just update zod schema + normalization).
+- Existing user rows work with zero backfill (empty/null → defaults).
+- In-blob `settingsUpdatedAt` provides a fine-grained audit trail for preference changes.
+- `schemaVersion` enables future shape migration without table-level migrations.
+
+### Negative / Accepted tradeoffs
+
+- **No native DB constraint** on the "at least one channel on" rule — invalid combinations can be written via direct SQL or any writer that bypasses tRPC validation.
+- **Weaker static typing** at the Postgres level vs. dedicated boolean columns; all type safety comes from zod in TS and pattern matching in Elixir.
+- **Dual normalization implementations** (TS + Elixir) can drift; requires discipline or a shared schema doc.
+- **No index** on JSONB paths unless needed for queries — if analytics or querying by a specific flag at scale is needed later, consider GIN indexes or extracting to typed columns.
+
+## Revisit triggers
+
+Consider revisiting this approach when any of the following arise:
+
+- Need **DB-enforced invariants** (e.g. add a Postgres `CHECK` on JSONB paths, or promote critical flags to typed columns).
+- Need **reporting/analytics** on specific settings flags at scale (JSONB path queries may be slower than indexed columns).
+- **Multiple writers** outside tRPC that must obey the same validation rules (argues for a DB constraint or centralized write service).
+- **Partial update write skew** becomes a concern (concurrent modifications to different JSONB keys without row-level locking).
+- The number of settings grows large enough that a **dedicated `user_settings` table** would provide cleaner domain separation.

--- a/prisma/migrations/20260412000000_add_user_settings_jsonb/migration.sql
+++ b/prisma/migrations/20260412000000_add_user_settings_jsonb/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN "userSettings" JSONB DEFAULT '{}';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -296,6 +296,8 @@ model User {
   team                   Team?      @relation(fields: [teamId], references: [id], onUpdate: NoAction, map: "FK_77f62757967de516e50ff134e35")
   // [1-n] settings modified by this user
   modifiedSettings       Settings[]
+  // JSONB blob for per-user preferences (notification toggles, future settings). See docs/adr/0001.
+  userSettings           Json?     @default("{}") @db.JsonB
 
   @@map("user")
 }

--- a/src/DAO/v2/UserDAO.ts
+++ b/src/DAO/v2/UserDAO.ts
@@ -69,7 +69,7 @@ export default class UserDAO {
 
     public async createUsers(userObjs: Partial<User>[]): Promise<PublicUser[]> {
         await this.userDb.createMany({
-            data: userObjs.map(user => ({
+            data: userObjs.map(({ userSettings: _userSettings, ...user }) => ({
                 ...user,
                 email: user.email || "",
                 espnMember: user.espnMember ?? undefined,

--- a/src/utils/userSettings.ts
+++ b/src/utils/userSettings.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+
+/**
+ * JSONB shape for `user.userSettings`. See docs/adr/0001-user-settings-jsonb-on-user.md.
+ *
+ * Schema version 1: notification preferences for trade workflow.
+ */
+
+const CURRENT_SCHEMA_VERSION = 1;
+
+const notificationsSchema = z.object({
+    tradeActionDiscordDm: z.boolean().nullable().optional(),
+    tradeActionEmail: z.boolean().nullable().optional(),
+}).optional().nullable();
+
+export const userSettingsSchema = z.object({
+    schemaVersion: z.number().int().nullable().optional(),
+    settingsUpdatedAt: z.string().nullable().optional(),
+    notifications: notificationsSchema,
+}).nullable().optional();
+
+export type UserSettingsRaw = z.infer<typeof userSettingsSchema>;
+
+export interface ResolvedNotifications {
+    tradeActionDiscordDm: boolean;
+    tradeActionEmail: boolean;
+}
+
+export interface NormalizedUserSettings {
+    schemaVersion: number;
+    settingsUpdatedAt: string | null;
+    notifications: ResolvedNotifications;
+}
+
+const DEFAULT_TRADE_ACTION_EMAIL = true;
+const DEFAULT_TRADE_ACTION_DISCORD_DM = false;
+
+/**
+ * Normalize a raw `userSettings` JSONB value into resolved booleans.
+ * Handles null, undefined, empty `{}`, missing keys, and JSON null values.
+ */
+export function normalizeUserSettings(raw: unknown): NormalizedUserSettings {
+    if (raw == null || (typeof raw === "object" && Object.keys(raw as object).length === 0)) {
+        return {
+            schemaVersion: CURRENT_SCHEMA_VERSION,
+            settingsUpdatedAt: null,
+            notifications: {
+                tradeActionDiscordDm: DEFAULT_TRADE_ACTION_DISCORD_DM,
+                tradeActionEmail: DEFAULT_TRADE_ACTION_EMAIL,
+            },
+        };
+    }
+
+    const parsed = userSettingsSchema.safeParse(raw);
+    const data = parsed.success ? parsed.data : null;
+
+    const notifications = data?.notifications;
+
+    return {
+        schemaVersion: data?.schemaVersion ?? CURRENT_SCHEMA_VERSION,
+        settingsUpdatedAt: data?.settingsUpdatedAt ?? null,
+        notifications: {
+            tradeActionDiscordDm: notifications?.tradeActionDiscordDm ?? DEFAULT_TRADE_ACTION_DISCORD_DM,
+            tradeActionEmail: notifications?.tradeActionEmail ?? DEFAULT_TRADE_ACTION_EMAIL,
+        },
+    };
+}
+
+export class NotificationSettingsValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "NotificationSettingsValidationError";
+    }
+}
+
+/**
+ * Validate that at least one trade notification channel is enabled.
+ * Throws `NotificationSettingsValidationError` if both are off.
+ */
+export function validateNotificationInvariant(resolved: ResolvedNotifications): void {
+    if (!resolved.tradeActionDiscordDm && !resolved.tradeActionEmail) {
+        throw new NotificationSettingsValidationError(
+            "At least one trade notification channel must be enabled (Discord DMs or trade emails)."
+        );
+    }
+}
+
+export interface NotificationPatchInput {
+    tradeActionDiscordDm?: boolean;
+    tradeActionEmail?: boolean;
+}
+
+/**
+ * Merge a partial notification update into the existing raw settings blob,
+ * normalize, validate, stamp `settingsUpdatedAt`, and return the full blob
+ * ready for Prisma `user.update({ data: { userSettings: result } })`.
+ */
+export function mergeAndValidateNotificationUpdate(
+    existingRaw: unknown,
+    patch: NotificationPatchInput
+): Record<string, unknown> {
+    const existing = normalizeUserSettings(existingRaw);
+
+    const merged: ResolvedNotifications = {
+        tradeActionDiscordDm: patch.tradeActionDiscordDm ?? existing.notifications.tradeActionDiscordDm,
+        tradeActionEmail: patch.tradeActionEmail ?? existing.notifications.tradeActionEmail,
+    };
+
+    validateNotificationInvariant(merged);
+
+    const raw = (existingRaw != null && typeof existingRaw === "object") ? { ...(existingRaw as Record<string, unknown>) } : {};
+
+    return {
+        ...raw,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+        settingsUpdatedAt: new Date().toISOString(),
+        notifications: {
+            ...((raw.notifications && typeof raw.notifications === "object") ? raw.notifications : {}),
+            tradeActionDiscordDm: merged.tradeActionDiscordDm,
+            tradeActionEmail: merged.tradeActionEmail,
+        },
+    };
+}
+
+export { CURRENT_SCHEMA_VERSION };

--- a/src/utils/userSettings.ts
+++ b/src/utils/userSettings.ts
@@ -8,16 +8,22 @@ import { z } from "zod";
 
 const CURRENT_SCHEMA_VERSION = 1;
 
-const notificationsSchema = z.object({
-    tradeActionDiscordDm: z.boolean().nullable().optional(),
-    tradeActionEmail: z.boolean().nullable().optional(),
-}).optional().nullable();
+const notificationsSchema = z
+    .object({
+        tradeActionDiscordDm: z.boolean().nullable().optional(),
+        tradeActionEmail: z.boolean().nullable().optional(),
+    })
+    .optional()
+    .nullable();
 
-export const userSettingsSchema = z.object({
-    schemaVersion: z.number().int().nullable().optional(),
-    settingsUpdatedAt: z.string().nullable().optional(),
-    notifications: notificationsSchema,
-}).nullable().optional();
+export const userSettingsSchema = z
+    .object({
+        schemaVersion: z.number().int().nullable().optional(),
+        settingsUpdatedAt: z.string().nullable().optional(),
+        notifications: notificationsSchema,
+    })
+    .nullable()
+    .optional();
 
 export type UserSettingsRaw = z.infer<typeof userSettingsSchema>;
 
@@ -40,7 +46,7 @@ const DEFAULT_TRADE_ACTION_DISCORD_DM = false;
  * Handles null, undefined, empty `{}`, missing keys, and JSON null values.
  */
 export function normalizeUserSettings(raw: unknown): NormalizedUserSettings {
-    if (raw == null || (typeof raw === "object" && Object.keys(raw as object).length === 0)) {
+    if (raw == null || (typeof raw === "object" && Object.keys(raw).length === 0)) {
         return {
             schemaVersion: CURRENT_SCHEMA_VERSION,
             settingsUpdatedAt: null,
@@ -114,14 +120,15 @@ export function mergeAndValidateNotificationUpdate(
 
     validateNotificationInvariant(merged);
 
-    const raw = (existingRaw != null && typeof existingRaw === "object") ? { ...(existingRaw as Record<string, unknown>) } : {};
+    const raw =
+        existingRaw != null && typeof existingRaw === "object" ? { ...(existingRaw as Record<string, unknown>) } : {};
 
     return {
         ...raw,
         schemaVersion: CURRENT_SCHEMA_VERSION,
         settingsUpdatedAt: new Date().toISOString(),
         notifications: {
-            ...((raw.notifications && typeof raw.notifications === "object") ? raw.notifications : {}),
+            ...(raw.notifications && typeof raw.notifications === "object" ? raw.notifications : {}),
             tradeActionDiscordDm: merged.tradeActionDiscordDm,
             tradeActionEmail: merged.tradeActionEmail,
         },

--- a/src/utils/userSettings.ts
+++ b/src/utils/userSettings.ts
@@ -90,6 +90,12 @@ export interface NotificationPatchInput {
     tradeActionEmail?: boolean;
 }
 
+export interface UserSettingsBlob extends Record<string, unknown> {
+    schemaVersion: number;
+    settingsUpdatedAt: string;
+    notifications: Record<string, unknown> & ResolvedNotifications;
+}
+
 /**
  * Merge a partial notification update into the existing raw settings blob,
  * normalize, validate, stamp `settingsUpdatedAt`, and return the full blob
@@ -98,7 +104,7 @@ export interface NotificationPatchInput {
 export function mergeAndValidateNotificationUpdate(
     existingRaw: unknown,
     patch: NotificationPatchInput
-): Record<string, unknown> {
+): UserSettingsBlob {
     const existing = normalizeUserSettings(existingRaw);
 
     const merged: ResolvedNotifications = {

--- a/tests/unit/api/routes/v2/trpc/client.test.ts
+++ b/tests/unit/api/routes/v2/trpc/client.test.ts
@@ -127,7 +127,8 @@ describe("[TRPC] Client Router Unit Tests", () => {
         csvName: null,
         espnMember: null,
         teamId: null,
-        isAdmin: () => true, // Computed property that returns a function
+        userSettings: {},
+        isAdmin: () => true,
     };
 
     beforeAll(() => {

--- a/tests/unit/utils/userSettings.test.ts
+++ b/tests/unit/utils/userSettings.test.ts
@@ -1,0 +1,142 @@
+import {
+    normalizeUserSettings,
+    validateNotificationInvariant,
+    mergeAndValidateNotificationUpdate,
+    NotificationSettingsValidationError,
+} from "../../../src/utils/userSettings";
+
+describe("normalizeUserSettings", () => {
+    it("returns defaults for null", () => {
+        const result = normalizeUserSettings(null);
+        expect(result.notifications.tradeActionEmail).toBe(true);
+        expect(result.notifications.tradeActionDiscordDm).toBe(false);
+        expect(result.settingsUpdatedAt).toBeNull();
+        expect(result.schemaVersion).toBe(1);
+    });
+
+    it("returns defaults for undefined", () => {
+        const result = normalizeUserSettings(undefined);
+        expect(result.notifications.tradeActionEmail).toBe(true);
+        expect(result.notifications.tradeActionDiscordDm).toBe(false);
+    });
+
+    it("returns defaults for empty object", () => {
+        const result = normalizeUserSettings({});
+        expect(result.notifications.tradeActionEmail).toBe(true);
+        expect(result.notifications.tradeActionDiscordDm).toBe(false);
+    });
+
+    it("returns defaults for empty notifications", () => {
+        const result = normalizeUserSettings({ notifications: {} });
+        expect(result.notifications.tradeActionEmail).toBe(true);
+        expect(result.notifications.tradeActionDiscordDm).toBe(false);
+    });
+
+    it("respects explicit false for email", () => {
+        const result = normalizeUserSettings({
+            notifications: { tradeActionEmail: false },
+        });
+        expect(result.notifications.tradeActionEmail).toBe(false);
+        expect(result.notifications.tradeActionDiscordDm).toBe(false);
+    });
+
+    it("respects explicit true for Discord DM", () => {
+        const result = normalizeUserSettings({
+            notifications: { tradeActionDiscordDm: true },
+        });
+        expect(result.notifications.tradeActionDiscordDm).toBe(true);
+        expect(result.notifications.tradeActionEmail).toBe(true);
+    });
+
+    it("preserves settingsUpdatedAt when present", () => {
+        const ts = "2026-04-12T01:00:00.000Z";
+        const result = normalizeUserSettings({ settingsUpdatedAt: ts });
+        expect(result.settingsUpdatedAt).toBe(ts);
+    });
+
+    it("preserves schemaVersion when present", () => {
+        const result = normalizeUserSettings({ schemaVersion: 2 });
+        expect(result.schemaVersion).toBe(2);
+    });
+
+    it("handles JSON null values for notification keys as defaults", () => {
+        const result = normalizeUserSettings({
+            notifications: { tradeActionDiscordDm: null, tradeActionEmail: null },
+        });
+        expect(result.notifications.tradeActionDiscordDm).toBe(false);
+        expect(result.notifications.tradeActionEmail).toBe(true);
+    });
+
+    it("handles garbage input gracefully (falls back to defaults)", () => {
+        const result = normalizeUserSettings("not an object");
+        expect(result.notifications.tradeActionEmail).toBe(true);
+        expect(result.notifications.tradeActionDiscordDm).toBe(false);
+    });
+});
+
+describe("validateNotificationInvariant", () => {
+    it("does not throw when email is on", () => {
+        expect(() =>
+            validateNotificationInvariant({ tradeActionDiscordDm: false, tradeActionEmail: true })
+        ).not.toThrow();
+    });
+
+    it("does not throw when Discord is on", () => {
+        expect(() =>
+            validateNotificationInvariant({ tradeActionDiscordDm: true, tradeActionEmail: false })
+        ).not.toThrow();
+    });
+
+    it("does not throw when both are on", () => {
+        expect(() =>
+            validateNotificationInvariant({ tradeActionDiscordDm: true, tradeActionEmail: true })
+        ).not.toThrow();
+    });
+
+    it("throws when both are off", () => {
+        expect(() =>
+            validateNotificationInvariant({ tradeActionDiscordDm: false, tradeActionEmail: false })
+        ).toThrow(NotificationSettingsValidationError);
+    });
+});
+
+describe("mergeAndValidateNotificationUpdate", () => {
+    it("patches a single key onto empty blob", () => {
+        const result = mergeAndValidateNotificationUpdate({}, { tradeActionDiscordDm: true });
+        expect(result.notifications).toEqual({
+            tradeActionDiscordDm: true,
+            tradeActionEmail: true,
+        });
+        expect(result.schemaVersion).toBe(1);
+        expect(typeof result.settingsUpdatedAt).toBe("string");
+    });
+
+    it("patches a single key onto existing blob", () => {
+        const existing = {
+            schemaVersion: 1,
+            settingsUpdatedAt: "2026-01-01T00:00:00.000Z",
+            notifications: { tradeActionDiscordDm: true, tradeActionEmail: true },
+        };
+        const result = mergeAndValidateNotificationUpdate(existing, { tradeActionEmail: false });
+        expect(result.notifications).toEqual({
+            tradeActionDiscordDm: true,
+            tradeActionEmail: false,
+        });
+        expect(result.settingsUpdatedAt).not.toBe("2026-01-01T00:00:00.000Z");
+    });
+
+    it("rejects both-off after merge", () => {
+        const existing = {
+            notifications: { tradeActionDiscordDm: false, tradeActionEmail: true },
+        };
+        expect(() =>
+            mergeAndValidateNotificationUpdate(existing, { tradeActionEmail: false })
+        ).toThrow(NotificationSettingsValidationError);
+    });
+
+    it("preserves extra keys in the blob", () => {
+        const existing = { schemaVersion: 1, someOtherSetting: "keep me" };
+        const result = mergeAndValidateNotificationUpdate(existing, { tradeActionDiscordDm: true });
+        expect((result as Record<string, unknown>).someOtherSetting).toBe("keep me");
+    });
+});

--- a/tests/unit/utils/userSettings.test.ts
+++ b/tests/unit/utils/userSettings.test.ts
@@ -94,9 +94,9 @@ describe("validateNotificationInvariant", () => {
     });
 
     it("throws when both are off", () => {
-        expect(() =>
-            validateNotificationInvariant({ tradeActionDiscordDm: false, tradeActionEmail: false })
-        ).toThrow(NotificationSettingsValidationError);
+        expect(() => validateNotificationInvariant({ tradeActionDiscordDm: false, tradeActionEmail: false })).toThrow(
+            NotificationSettingsValidationError
+        );
     });
 });
 
@@ -129,9 +129,9 @@ describe("mergeAndValidateNotificationUpdate", () => {
         const existing = {
             notifications: { tradeActionDiscordDm: false, tradeActionEmail: true },
         };
-        expect(() =>
-            mergeAndValidateNotificationUpdate(existing, { tradeActionEmail: false })
-        ).toThrow(NotificationSettingsValidationError);
+        expect(() => mergeAndValidateNotificationUpdate(existing, { tradeActionEmail: false })).toThrow(
+            NotificationSettingsValidationError
+        );
     });
 
     it("preserves extra keys in the blob", () => {


### PR DESCRIPTION
## Summary
- Adds a `userSettings` JSONB column (`Json?`) to the `User` Prisma model with a `'{}'` default, plus migration
- Implements `normalizeUserSettings()` (zod-based) with asymmetric defaults: `tradeActionEmail` → true, `tradeActionDiscordDm` → false when absent/null
- Includes `mergeAndValidateNotificationUpdate()` for patch-based updates with "at least one channel on" invariant enforcement, `schemaVersion` tracking, and `settingsUpdatedAt` timestamping
- Adds ADR 0001 documenting the JSONB-on-user-table decision, alternatives considered, and revisit triggers
- Comprehensive unit tests for normalization, invariant validation, and merge logic

## Dependencies
None — this is the base branch for the user notification settings feature.

## Test plan
- [ ] Run `make test-unit` — new `userSettings.test.ts` passes
- [ ] Run `make typecheck` — no type errors
- [ ] Run migration against local DB: `npx prisma migrate dev`
- [ ] Verify existing users with `null`/`{}` userSettings resolve to email=on, Discord DM=off


Made with [Cursor](https://cursor.com)