### PR TITLE
feat: structured search filters for staff trade history

### DIFF
--- a/docs/adr/0001-staff-trade-search-postgres-structured.md
+++ b/docs/adr/0001-staff-trade-search-postgres-structured.md
@@ -1,0 +1,58 @@
+# ADR 0001: Staff trade search — structured Postgres filters
+
+**Date:** 2026-04-13
+**Status:** Accepted
+**Deciders:** Akosua Asante
+
+## Context
+
+The admin/commissioner trade history page needs multi-axis search so staff can find trades by date range, player involvement, draft pick involvement, and status. The page already has server-side pagination and status filtering via the `trades.listStaff` tRPC procedure backed by Prisma.
+
+The trade data model is **fully normalized**: `trade` → `trade_item` (polymorphic player or pick) → `player` / `draft_pick`, and `trade` → `trade_participant` → `team`. Player and team names are stored in their own tables and referenced by UUID.
+
+We evaluated several approaches:
+
+| Approach | Operational cost | Fuzzy / substring | Fit for normalized schema |
+|---|---|---|---|
+| Structured Prisma `where` + joins | None (existing stack) | No | Excellent |
+| `ILIKE` on player/team names | Low (no extension) | Partial (substring) | Moderate (leading wildcards bypass B-tree) |
+| PostgreSQL `tsvector` / `tsquery` | Medium (migration, raw SQL, index maintenance) | Stemming/prefix | Good for denormalized docs, awkward for proper nouns |
+| `pg_trgm` trigram extension | Medium (CREATE EXTENSION, GIN index) | Fuzzy + substring | Good for names |
+| Elasticsearch / OpenSearch / Meilisearch | High (new infra, sync pipeline, hosting) | Full relevance | Overkill for staff-only traffic |
+
+## Decision
+
+Use **structured relational filters in Postgres** via Prisma's `where` clause composition:
+
+- **Status:** existing `{ in: [...] }` filter (unchanged).
+- **Date range:** `dateFrom` / `dateTo` on a configurable column (`dateCreated`, `submittedAt`, `acceptedOnDate`, or `declinedAt`).
+- **Player:** `playerId` UUID matched against `tradeItems.some { tradeItemType: PLAYER, tradeItemId }`.
+- **Draft pick:** composite `{ pickType, season, round, originalOwnerId }` resolved to a `draft_pick.id` via `findFirst`, then matched against `tradeItems.some { tradeItemType: PICK, tradeItemId }`. When no matching pick exists, the search returns an empty result set rather than an error.
+
+Player discovery uses the existing `admin.players.search` tRPC procedure (case-insensitive `contains` via Prisma) for an autocomplete dropdown. The user selects a player, and the UUID is sent as `playerId` to `listStaff`. No free-text name search is performed against the trade list itself.
+
+## Rationale
+
+- **Zero operational cost.** No new infrastructure, extensions, or index types. The existing Prisma client, Postgres instance, and tRPC transport handle everything.
+- **Fits the normalized schema.** The filter axes map directly to existing FK relationships and indexed columns. Prisma's `some` relation filter compiles to efficient `EXISTS` subqueries.
+- **Staff-only traffic.** The admin trade history page serves a handful of commissioners and admins, not a general user population. Query complexity and latency requirements are modest.
+- **Incremental delivery.** Each filter axis (status, date, player, pick) is independently useful and testable. No big-bang migration or data pipeline required.
+
+## Consequences
+
+- **Possible slow queries on unindexed filter combinations.** If `EXPLAIN` reveals sequential scans on hot queries (e.g. filtering by `acceptedOnDate` range across many trades), we should add targeted composite indexes. The existing indexes cover `status + dateCreated`, `tradeItemType`, and `senderId + recipientId`.
+- **No fuzzy or substring search on the trade list itself.** Admins must use the autocomplete to find a player by name, then filter. They cannot type "Tr" into a search box and see all trades involving players whose names start with "Tr." This is an acceptable tradeoff for v1.
+- **Monitoring.** We should track query duration for `trades.listStaff` via existing OpenTelemetry spans (`trpc.trades.listStaff`) and revisit if P95 latency degrades after the new filters ship.
+
+## Caching
+
+- **Client LRU + TTL cache** (in-memory, ~30 entries, ~45 s TTL) keyed by serialized `listStaff` input. The goal is deduping rapid repeat requests during debounced filter changes and smooth back/forward navigation — not a durable cache.
+- **Why not server-side or HTTP cache first:** the V3 client uses a vanilla `createTRPCProxyClient` (no TanStack Query). Authenticated batched POST requests do not lend themselves to simple `Cache-Control` without careful key design and invalidation. A Redis/memory cache on the server could help multi-admin scenarios but adds staleness and invalidation work for volatile trade lists. Deferred until metrics justify it.
+- **Why not "DB caching":** PostgreSQL's shared buffer pool already caches hot data pages automatically. This feature does not require materialized views or a separate cache layer for v1.
+- **Prisma vs TypeORM:** Prisma Client does not offer a built-in query result cache analogous to TypeORM's optional result cache (which supported Redis or in-memory). Prisma sends queries to the database on every call unless the application wraps calls explicitly or uses Prisma Accelerate (a separate hosted product). This ADR documents the decision so future readers do not assume an ORM toggle exists.
+
+## Future work
+
+- **Fuzzy / full-text player name search** directly in the trade list (without requiring autocomplete selection first). This could use `pg_trgm` with a GIN index on `player.name` joined through `trade_item`, or a lightweight `tsvector` index over a denormalized per-trade text blob. Revisit if admins report friction with the autocomplete-first flow.
+- **Server-side caching** (Redis or in-memory with short TTL) if metrics show repeated identical queries or high DB load from staff searches.
+- **Team name filter** as a direct input (not just as part of pick filter). Currently team filtering is implicit via the pick's `originalOwnerId` or by inspecting `tradeParticipants` — a dedicated "team involved" filter could be added.

--- a/packages/trpc-types/README.md
+++ b/packages/trpc-types/README.md
@@ -156,6 +156,11 @@ repo reflects the published state.
 
 ## Changelog
 
+### 1.16.0
+
+- Extend `trades.listStaff` input with structured search filters: `dateFrom`, `dateTo`, `dateField`, `playerId`, and `pick` (composite draft pick filter)
+- Used by V3 admin trade history page for server-side search/filtering
+
 ### 1.15.0
 
 - Add `notifications` router with `get` query and `update` mutation procedure types

--- a/packages/trpc-types/README.md
+++ b/packages/trpc-types/README.md
@@ -156,6 +156,11 @@ repo reflects the published state.
 
 ## Changelog
 
+### 1.16.1
+
+- `trades.listStaff`: rename `playerId` to `playerIds` (array, max 10) for multi-player AND filtering
+- `trades.listStaff`: make `pick` sub-fields (`pickType`, `season`, `round`, `originalOwnerId`) individually optional; at least one required (partial pick filter)
+
 ### 1.16.0
 
 - Extend `trades.listStaff` input with structured search filters: `dateFrom`, `dateTo`, `dateField`, `playerId`, and `pick` (composite draft pick filter)

--- a/packages/trpc-types/package-lock.json
+++ b/packages/trpc-types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trademachine/trpc-types",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trademachine/trpc-types",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^4.9.0"

--- a/packages/trpc-types/package-lock.json
+++ b/packages/trpc-types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trademachine/trpc-types",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trademachine/trpc-types",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^4.9.0"

--- a/packages/trpc-types/package.json
+++ b/packages/trpc-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akosasante/trpc-types",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Shared tRPC types for TradeMachine client and server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/trpc-types/package.json
+++ b/packages/trpc-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akosasante/trpc-types",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Shared tRPC types for TradeMachine client and server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/DAO/v2/PlayerDAO.ts
+++ b/src/DAO/v2/PlayerDAO.ts
@@ -5,7 +5,7 @@ import { inspect } from "util";
 import { ExtendedPrismaClient } from "../../bootstrap/prisma-db";
 
 export type PlayerWithTeam = Player & {
-    ownerTeam: { id: string; name: string } | null;
+    ownerTeam: { id: string; name: string; owners: { csvName: string | null }[] } | null;
 };
 
 export default class PlayerDAO {
@@ -40,7 +40,7 @@ export default class PlayerDAO {
                 orderBy: { name: "asc" },
                 skip: opts?.skip ?? 0,
                 take: opts?.take ?? 50,
-                include: { ownerTeam: { select: { id: true, name: true } } },
+                include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
             }),
             this.playerDb.count({ where }),
         ]);
@@ -51,7 +51,7 @@ export default class PlayerDAO {
     public async getPlayerById(id: string): Promise<PlayerWithTeam> {
         return (await this.playerDb.findUniqueOrThrow({
             where: { id },
-            include: { ownerTeam: { select: { id: true, name: true } } },
+            include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
         })) as unknown as PlayerWithTeam;
     }
 
@@ -70,7 +70,7 @@ export default class PlayerDAO {
                 playerDataId: data.playerDataId ?? null,
                 leagueTeamId: data.leagueTeamId ?? null,
             },
-            include: { ownerTeam: { select: { id: true, name: true } } },
+            include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
         })) as unknown as PlayerWithTeam;
     }
 
@@ -87,7 +87,7 @@ export default class PlayerDAO {
         return (await this.playerDb.update({
             where: { id },
             data,
-            include: { ownerTeam: { select: { id: true, name: true } } },
+            include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
         })) as unknown as PlayerWithTeam;
     }
 

--- a/src/DAO/v2/TeamDAO.ts
+++ b/src/DAO/v2/TeamDAO.ts
@@ -2,7 +2,7 @@ import { Prisma, TeamStatus } from "@prisma/client";
 import { ExtendedPrismaClient } from "../../bootstrap/prisma-db";
 
 const ownersSelect = {
-    select: { id: true, displayName: true, email: true, role: true, status: true },
+    select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
 } as const;
 
 export type TeamWithOwners = Prisma.Result<

--- a/src/DAO/v2/TradeDAO.ts
+++ b/src/DAO/v2/TradeDAO.ts
@@ -1,9 +1,29 @@
-import { Prisma, TradeStatus } from "@prisma/client";
+import { Prisma, TradeItemType, TradeStatus } from "@prisma/client";
 import { ExtendedPrismaClient } from "../../bootstrap/prisma-db";
 
 export interface AcceptedByEntry {
     by: string;
     at: string;
+}
+
+export type DateField = "CREATED" | "SUBMITTED" | "ACCEPTED" | "DECLINED";
+
+export interface PickFilter {
+    pickType: string;
+    season: number;
+    round: number;
+    originalOwnerId: string;
+}
+
+export interface StaffTradeFilters {
+    statuses?: TradeStatus[];
+    page: number;
+    pageSize: number;
+    dateFrom?: string;
+    dateTo?: string;
+    dateField?: DateField;
+    playerId?: string;
+    pick?: PickFilter;
 }
 
 /** The Prisma include shape used consistently across all DAO methods */
@@ -89,17 +109,30 @@ export default class TradeDAO {
 
     /**
      * All trades across the league, newest first. Intended for staff (admin/commissioner) views.
+     * Supports filtering by status, date range, player involvement, and draft pick involvement.
      * Does not hydrate player/pick entities on trade items (list UI only).
      */
-    public async getTradesPaginated(opts: {
-        statuses?: TradeStatus[];
-        page: number;
-        pageSize: number;
-    }): Promise<{ trades: PrismaTrade[]; total: number }> {
-        const { statuses, page, pageSize } = opts;
+    public async getTradesPaginated(
+        opts: StaffTradeFilters,
+        pickDb?: ExtendedPrismaClient["draftPick"]
+    ): Promise<{ trades: PrismaTrade[]; total: number }> {
+        const { statuses, page, pageSize, dateFrom, dateTo, dateField, playerId, pick } = opts;
         const skip = page * pageSize;
 
-        const where: Prisma.TradeWhereInput = statuses && statuses.length > 0 ? { status: { in: statuses } } : {};
+        const where = buildStaffTradeWhere({ statuses, dateFrom, dateTo, dateField, playerId });
+
+        if (pick && pickDb) {
+            const resolvedPickId = await resolvePickId(pickDb, pick);
+            if (!resolvedPickId) return { trades: [], total: 0 };
+            where.tradeItems = {
+                ...((where.tradeItems as Prisma.TradeItemListRelationFilter) ?? {}),
+                some: {
+                    ...((where.tradeItems as Prisma.TradeItemListRelationFilter)?.some ?? {}),
+                    tradeItemType: TradeItemType.PICK,
+                    tradeItemId: resolvedPickId,
+                },
+            };
+        }
 
         const [trades, total] = await Promise.all([
             this.tradeDb.findMany({
@@ -167,4 +200,59 @@ export default class TradeDAO {
         });
         return this.getTradeById(id);
     }
+}
+
+// ─── Extracted helpers (exported for unit testing) ────────────────────────────
+
+const DATE_FIELD_MAP: Record<DateField, keyof Prisma.TradeWhereInput> = {
+    CREATED: "dateCreated",
+    SUBMITTED: "submittedAt",
+    ACCEPTED: "acceptedOnDate",
+    DECLINED: "declinedAt",
+};
+
+export function buildStaffTradeWhere(opts: {
+    statuses?: TradeStatus[];
+    dateFrom?: string;
+    dateTo?: string;
+    dateField?: DateField;
+    playerId?: string;
+}): Prisma.TradeWhereInput {
+    const where: Prisma.TradeWhereInput = {};
+
+    if (opts.statuses && opts.statuses.length > 0) {
+        where.status = { in: opts.statuses };
+    }
+
+    if (opts.dateFrom || opts.dateTo) {
+        const column = DATE_FIELD_MAP[opts.dateField ?? "CREATED"];
+        const range: Prisma.DateTimeNullableFilter = {};
+        if (opts.dateFrom) range.gte = new Date(opts.dateFrom);
+        if (opts.dateTo) range.lte = new Date(opts.dateTo);
+        (where as Record<string, unknown>)[column as string] = range;
+    }
+
+    if (opts.playerId) {
+        where.tradeItems = {
+            some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: opts.playerId },
+        };
+    }
+
+    return where;
+}
+
+export async function resolvePickId(
+    pickDb: ExtendedPrismaClient["draftPick"],
+    pick: PickFilter
+): Promise<string | null> {
+    const found = await pickDb.findFirst({
+        where: {
+            type: pick.pickType as Prisma.EnumPickLeagueLevelFilter["equals"],
+            season: pick.season,
+            round: new Prisma.Decimal(pick.round),
+            originalOwnerId: pick.originalOwnerId,
+        },
+        select: { id: true },
+    });
+    return found?.id ?? null;
 }

--- a/src/DAO/v2/TradeDAO.ts
+++ b/src/DAO/v2/TradeDAO.ts
@@ -9,10 +9,10 @@ export interface AcceptedByEntry {
 export type DateField = "CREATED" | "SUBMITTED" | "ACCEPTED" | "DECLINED";
 
 export interface PickFilter {
-    pickType: string;
-    season: number;
-    round: number;
-    originalOwnerId: string;
+    pickType?: string;
+    season?: number;
+    round?: number;
+    originalOwnerId?: string;
 }
 
 export interface StaffTradeFilters {
@@ -22,7 +22,7 @@ export interface StaffTradeFilters {
     dateFrom?: string;
     dateTo?: string;
     dateField?: DateField;
-    playerId?: string;
+    playerIds?: string[];
     pick?: PickFilter;
 }
 
@@ -116,22 +116,21 @@ export default class TradeDAO {
         opts: StaffTradeFilters,
         pickDb?: ExtendedPrismaClient["draftPick"]
     ): Promise<{ trades: PrismaTrade[]; total: number }> {
-        const { statuses, page, pageSize, dateFrom, dateTo, dateField, playerId, pick } = opts;
+        const { statuses, page, pageSize, dateFrom, dateTo, dateField, playerIds, pick } = opts;
         const skip = page * pageSize;
 
-        const where = buildStaffTradeWhere({ statuses, dateFrom, dateTo, dateField, playerId });
+        const where = buildStaffTradeWhere({ statuses, dateFrom, dateTo, dateField, playerIds });
 
         if (pick && pickDb) {
-            const resolvedPickId = await resolvePickId(pickDb, pick);
-            if (!resolvedPickId) return { trades: [], total: 0 };
-            where.tradeItems = {
-                ...((where.tradeItems as Prisma.TradeItemListRelationFilter) ?? {}),
-                some: {
-                    ...((where.tradeItems as Prisma.TradeItemListRelationFilter)?.some ?? {}),
-                    tradeItemType: TradeItemType.PICK,
-                    tradeItemId: resolvedPickId,
+            const resolvedIds = await resolvePickIds(pickDb, pick);
+            if (resolvedIds.length === 0) return { trades: [], total: 0 };
+            const andClauses = (where.AND as Prisma.TradeWhereInput[]) ?? [];
+            andClauses.push({
+                tradeItems: {
+                    some: { tradeItemType: TradeItemType.PICK, tradeItemId: { in: resolvedIds } },
                 },
-            };
+            });
+            where.AND = andClauses;
         }
 
         const [trades, total] = await Promise.all([
@@ -216,7 +215,7 @@ export function buildStaffTradeWhere(opts: {
     dateFrom?: string;
     dateTo?: string;
     dateField?: DateField;
-    playerId?: string;
+    playerIds?: string[];
 }): Prisma.TradeWhereInput {
     const where: Prisma.TradeWhereInput = {};
 
@@ -232,27 +231,26 @@ export function buildStaffTradeWhere(opts: {
         (where as Record<string, unknown>)[column as string] = range;
     }
 
-    if (opts.playerId) {
-        where.tradeItems = {
-            some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: opts.playerId },
-        };
+    if (opts.playerIds && opts.playerIds.length > 0) {
+        const andClauses: Prisma.TradeWhereInput[] = (where.AND as Prisma.TradeWhereInput[]) ?? [];
+        for (const pid of opts.playerIds) {
+            andClauses.push({
+                tradeItems: { some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: pid } },
+            });
+        }
+        where.AND = andClauses;
     }
 
     return where;
 }
 
-export async function resolvePickId(
-    pickDb: ExtendedPrismaClient["draftPick"],
-    pick: PickFilter
-): Promise<string | null> {
-    const found = await pickDb.findFirst({
-        where: {
-            type: pick.pickType as Prisma.EnumPickLeagueLevelFilter["equals"],
-            season: pick.season,
-            round: new Prisma.Decimal(pick.round),
-            originalOwnerId: pick.originalOwnerId,
-        },
-        select: { id: true },
-    });
-    return found?.id ?? null;
+export async function resolvePickIds(pickDb: ExtendedPrismaClient["draftPick"], pick: PickFilter): Promise<string[]> {
+    const where: Prisma.DraftPickWhereInput = {};
+    if (pick.pickType) where.type = pick.pickType as Prisma.EnumPickLeagueLevelFilter["equals"];
+    if (pick.season !== undefined) where.season = pick.season;
+    if (pick.round !== undefined) where.round = new Prisma.Decimal(pick.round);
+    if (pick.originalOwnerId) where.originalOwnerId = pick.originalOwnerId;
+
+    const found = await pickDb.findMany({ where, select: { id: true } });
+    return found.map(p => p.id);
 }

--- a/src/api/routes/v2/routers/trade.ts
+++ b/src/api/routes/v2/routers/trade.ts
@@ -349,13 +349,16 @@ export const tradeRouter = router({
                 dateFrom: z.string().optional(),
                 dateTo: z.string().optional(),
                 dateField: z.enum(["CREATED", "SUBMITTED", "ACCEPTED", "DECLINED"]).optional(),
-                playerId: z.string().uuid().optional(),
+                playerIds: z.array(z.string().uuid()).max(10).optional(),
                 pick: z
                     .object({
-                        pickType: z.string(),
-                        season: z.number().int(),
-                        round: z.number(),
-                        originalOwnerId: z.string().uuid(),
+                        pickType: z.string().optional(),
+                        season: z.number().int().optional(),
+                        round: z.number().optional(),
+                        originalOwnerId: z.string().uuid().optional(),
+                    })
+                    .refine(p => p.pickType || p.season !== undefined || p.round !== undefined || p.originalOwnerId, {
+                        message: "At least one pick filter field is required",
                     })
                     .optional(),
             })
@@ -383,7 +386,7 @@ export const tradeRouter = router({
                         dateFrom: input.dateFrom,
                         dateTo: input.dateTo,
                         dateField: input.dateField,
-                        playerId: input.playerId,
+                        playerIds: input.playerIds,
                         pick: input.pick,
                     },
                     ctx.prisma.draftPick

--- a/src/api/routes/v2/routers/trade.ts
+++ b/src/api/routes/v2/routers/trade.ts
@@ -337,6 +337,7 @@ export const tradeRouter = router({
 
     /**
      * Paginated list of ALL trades (not team-scoped). Restricted to admin and commissioner roles.
+     * Supports structured filters: status, date range, player involvement, and draft pick.
      * Trade items include sender/recipient teams but are not hydrated with player/pick entities.
      */
     listStaff: protectedProcedure
@@ -345,6 +346,18 @@ export const tradeRouter = router({
                 statuses: z.array(z.nativeEnum(TradeStatus)).optional(),
                 page: z.number().int().min(0).default(0),
                 pageSize: z.number().int().min(1).max(50).default(20),
+                dateFrom: z.string().optional(),
+                dateTo: z.string().optional(),
+                dateField: z.enum(["CREATED", "SUBMITTED", "ACCEPTED", "DECLINED"]).optional(),
+                playerId: z.string().uuid().optional(),
+                pick: z
+                    .object({
+                        pickType: z.string(),
+                        season: z.number().int(),
+                        round: z.number(),
+                        originalOwnerId: z.string().uuid(),
+                    })
+                    .optional(),
             })
         )
         .query(
@@ -362,11 +375,19 @@ export const tradeRouter = router({
                 addSpanEvent("trades.listStaff.start");
 
                 const dao = new TradeDAO(ctx.prisma.trade);
-                const { trades, total } = await dao.getTradesPaginated({
-                    statuses: input.statuses,
-                    page: input.page,
-                    pageSize: input.pageSize,
-                });
+                const { trades, total } = await dao.getTradesPaginated(
+                    {
+                        statuses: input.statuses,
+                        page: input.page,
+                        pageSize: input.pageSize,
+                        dateFrom: input.dateFrom,
+                        dateTo: input.dateTo,
+                        dateField: input.dateField,
+                        playerId: input.playerId,
+                        pick: input.pick,
+                    },
+                    ctx.prisma.draftPick
+                );
 
                 addSpanEvent("trades.listStaff.success");
                 return {

--- a/tests/unit/DAO/v2/PlayerDAO.test.ts
+++ b/tests/unit/DAO/v2/PlayerDAO.test.ts
@@ -67,7 +67,7 @@ describe("[PRISMA] PlayerDAO", () => {
                     orderBy: { name: "asc" },
                     skip: 0,
                     take: 50,
-                    include: { ownerTeam: { select: { id: true, name: true } } },
+                    include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
                 })
             );
             expect(prisma.count).toHaveBeenCalledWith({ where: {} });
@@ -137,7 +137,7 @@ describe("[PRISMA] PlayerDAO", () => {
 
             expect(prisma.findUniqueOrThrow).toHaveBeenCalledWith({
                 where: { id: player.id },
-                include: { ownerTeam: { select: { id: true, name: true } } },
+                include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
             });
             expect(result.id).toBe(player.id);
         });
@@ -165,7 +165,7 @@ describe("[PRISMA] PlayerDAO", () => {
                     playerDataId: 999,
                     leagueTeamId: teamId,
                 },
-                include: { ownerTeam: { select: { id: true, name: true } } },
+                include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
             });
         });
 
@@ -183,7 +183,7 @@ describe("[PRISMA] PlayerDAO", () => {
                     playerDataId: null,
                     leagueTeamId: null,
                 },
-                include: { ownerTeam: { select: { id: true, name: true } } },
+                include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
             });
         });
     });
@@ -198,7 +198,7 @@ describe("[PRISMA] PlayerDAO", () => {
             expect(prisma.update).toHaveBeenCalledWith({
                 where: { id: player.id },
                 data: { name: "Updated Name" },
-                include: { ownerTeam: { select: { id: true, name: true } } },
+                include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
             });
             expect(result.name).toBe("Updated Name");
         });

--- a/tests/unit/DAO/v2/TeamDAO.test.ts
+++ b/tests/unit/DAO/v2/TeamDAO.test.ts
@@ -49,7 +49,9 @@ describe("[PRISMA] TeamDAO", () => {
             expect(prisma.findMany).toHaveBeenCalledWith({
                 orderBy: { name: "asc" },
                 include: {
-                    owners: { select: { id: true, displayName: true, email: true, role: true, status: true } },
+                    owners: {
+                        select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
+                    },
                 },
             });
             expect(result).toHaveLength(2);
@@ -66,7 +68,9 @@ describe("[PRISMA] TeamDAO", () => {
             expect(prisma.findUniqueOrThrow).toHaveBeenCalledWith({
                 where: { id: team.id },
                 include: {
-                    owners: { select: { id: true, displayName: true, email: true, role: true, status: true } },
+                    owners: {
+                        select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
+                    },
                 },
             });
             expect(result.id).toBe(team.id);
@@ -83,7 +87,9 @@ describe("[PRISMA] TeamDAO", () => {
             expect(prisma.create).toHaveBeenCalledWith({
                 data: { name: "New Team", espnId: 5, status: TeamStatus.ACTIVE },
                 include: {
-                    owners: { select: { id: true, displayName: true, email: true, role: true, status: true } },
+                    owners: {
+                        select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
+                    },
                 },
             });
             expect(result.name).toBe("New Team");
@@ -114,7 +120,9 @@ describe("[PRISMA] TeamDAO", () => {
                 where: { id: team.id },
                 data: { name: "Updated" },
                 include: {
-                    owners: { select: { id: true, displayName: true, email: true, role: true, status: true } },
+                    owners: {
+                        select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
+                    },
                 },
             });
             expect(result.name).toBe("Updated");
@@ -144,7 +152,9 @@ describe("[PRISMA] TeamDAO", () => {
             expect(prisma.delete).toHaveBeenCalledWith({
                 where: { id: team.id },
                 include: {
-                    owners: { select: { id: true, displayName: true, email: true, role: true, status: true } },
+                    owners: {
+                        select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
+                    },
                 },
             });
             expect(result.id).toBe(team.id);

--- a/tests/unit/DAO/v2/TradeDAO.test.ts
+++ b/tests/unit/DAO/v2/TradeDAO.test.ts
@@ -1,6 +1,11 @@
-import { PrismaClient, TradeStatus } from "@prisma/client";
+import { PrismaClient, TradeItemType, TradeStatus } from "@prisma/client";
 import { mockClear, mockDeep } from "jest-mock-extended";
-import TradeDAO, { AcceptedByEntry, PrismaTrade } from "../../../../src/DAO/v2/TradeDAO";
+import TradeDAO, {
+    AcceptedByEntry,
+    PrismaTrade,
+    buildStaffTradeWhere,
+    resolvePickId,
+} from "../../../../src/DAO/v2/TradeDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
 import logger from "../../../../src/bootstrap/logger";
 import { v4 as uuid } from "uuid";
@@ -309,5 +314,204 @@ describe("[PRISMA] TradeDAO", () => {
                 })
             );
         });
+    });
+
+    describe("getTradesPaginated (extended filters)", () => {
+        const tradeA = makeMinimalTrade({ id: uuid() });
+
+        it("should pass playerId filter as tradeItems.some constraint", async () => {
+            const playerId = uuid();
+            prisma.findMany.mockResolvedValueOnce([tradeA] as any);
+            prisma.count.mockResolvedValueOnce(1);
+
+            await dao.getTradesPaginated({ playerId, page: 0, pageSize: 20 });
+
+            expect(prisma.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        tradeItems: {
+                            some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: playerId },
+                        },
+                    }),
+                })
+            );
+        });
+
+        it("should pass date range filter on dateCreated by default", async () => {
+            prisma.findMany.mockResolvedValueOnce([] as any);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.getTradesPaginated({
+                dateFrom: "2026-01-01T00:00:00.000Z",
+                dateTo: "2026-06-01T00:00:00.000Z",
+                page: 0,
+                pageSize: 20,
+            });
+
+            const call = prisma.findMany.mock.calls[0][0] as { where: Record<string, unknown> };
+            expect(call.where).toHaveProperty("dateCreated");
+            expect(call.where.dateCreated).toEqual({
+                gte: new Date("2026-01-01T00:00:00.000Z"),
+                lte: new Date("2026-06-01T00:00:00.000Z"),
+            });
+        });
+
+        it("should filter on submittedAt when dateField is SUBMITTED", async () => {
+            prisma.findMany.mockResolvedValueOnce([] as any);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.getTradesPaginated({
+                dateFrom: "2026-03-01",
+                dateField: "SUBMITTED",
+                page: 0,
+                pageSize: 20,
+            });
+
+            const call = prisma.findMany.mock.calls[0][0] as { where: Record<string, unknown> };
+            expect(call.where).toHaveProperty("submittedAt");
+            expect(call.where).not.toHaveProperty("dateCreated");
+        });
+
+        it("should resolve pick and filter when pick + pickDb provided", async () => {
+            const pickDb = mockDeep<PrismaClient["draftPick"]>();
+            const resolvedPickId = uuid();
+            pickDb.findFirst.mockResolvedValueOnce({ id: resolvedPickId } as any);
+            prisma.findMany.mockResolvedValueOnce([tradeA] as any);
+            prisma.count.mockResolvedValueOnce(1);
+
+            await dao.getTradesPaginated(
+                {
+                    pick: { pickType: "MAJORS", season: 2026, round: 1, originalOwnerId: uuid() },
+                    page: 0,
+                    pageSize: 20,
+                },
+                pickDb as unknown as ExtendedPrismaClient["draftPick"]
+            );
+
+            expect(pickDb.findFirst).toHaveBeenCalledTimes(1);
+            expect(prisma.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        tradeItems: expect.objectContaining({
+                            some: expect.objectContaining({
+                                tradeItemType: TradeItemType.PICK,
+                                tradeItemId: resolvedPickId,
+                            }),
+                        }),
+                    }),
+                })
+            );
+        });
+
+        it("should return empty when pick cannot be resolved", async () => {
+            const pickDb = mockDeep<PrismaClient["draftPick"]>();
+            pickDb.findFirst.mockResolvedValueOnce(null);
+
+            const result = await dao.getTradesPaginated(
+                {
+                    pick: { pickType: "MAJORS", season: 2026, round: 99, originalOwnerId: uuid() },
+                    page: 0,
+                    pageSize: 20,
+                },
+                pickDb as unknown as ExtendedPrismaClient["draftPick"]
+            );
+
+            expect(result).toEqual({ trades: [], total: 0 });
+            expect(prisma.findMany).not.toHaveBeenCalled();
+        });
+
+        it("should combine status + date + player filters", async () => {
+            const playerId = uuid();
+            prisma.findMany.mockResolvedValueOnce([] as any);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.getTradesPaginated({
+                statuses: [TradeStatus.SUBMITTED],
+                dateFrom: "2026-01-01",
+                dateField: "ACCEPTED",
+                playerId,
+                page: 0,
+                pageSize: 10,
+            });
+
+            const call = prisma.findMany.mock.calls[0][0] as { where: Record<string, unknown> };
+            expect(call.where).toHaveProperty("status", { in: [TradeStatus.SUBMITTED] });
+            expect(call.where).toHaveProperty("acceptedOnDate");
+            expect(call.where).toHaveProperty("tradeItems");
+        });
+    });
+});
+
+// ─── Extracted helpers ────────────────────────────────────────────────────────
+
+describe("buildStaffTradeWhere", () => {
+    it("should return empty object when no filters provided", () => {
+        expect(buildStaffTradeWhere({})).toEqual({});
+    });
+
+    it("should include status filter", () => {
+        const where = buildStaffTradeWhere({ statuses: [TradeStatus.DRAFT, TradeStatus.REQUESTED] });
+        expect(where).toEqual({ status: { in: [TradeStatus.DRAFT, TradeStatus.REQUESTED] } });
+    });
+
+    it("should not include status when array is empty", () => {
+        const where = buildStaffTradeWhere({ statuses: [] });
+        expect(where).not.toHaveProperty("status");
+    });
+
+    it("should add dateCreated range when dateField omitted", () => {
+        const where = buildStaffTradeWhere({
+            dateFrom: "2026-01-01T00:00:00Z",
+            dateTo: "2026-12-31T23:59:59Z",
+        });
+        expect(where).toHaveProperty("dateCreated");
+        expect((where.dateCreated as { gte: Date; lte: Date }).gte).toEqual(new Date("2026-01-01T00:00:00Z"));
+    });
+
+    it("should map dateField DECLINED to declinedAt", () => {
+        const where = buildStaffTradeWhere({ dateFrom: "2026-06-01", dateField: "DECLINED" });
+        expect(where).toHaveProperty("declinedAt");
+        expect(where).not.toHaveProperty("dateCreated");
+    });
+
+    it("should add playerId as tradeItems.some filter", () => {
+        const pid = uuid();
+        const where = buildStaffTradeWhere({ playerId: pid });
+        expect(where.tradeItems).toEqual({
+            some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: pid },
+        });
+    });
+});
+
+describe("resolvePickId", () => {
+    const pickDb = mockDeep<PrismaClient["draftPick"]>();
+
+    afterEach(() => mockClear(pickDb));
+
+    it("should return the id when a matching pick exists", async () => {
+        const id = uuid();
+        pickDb.findFirst.mockResolvedValueOnce({ id } as any);
+
+        const result = await resolvePickId(pickDb as unknown as ExtendedPrismaClient["draftPick"], {
+            pickType: "MAJORS",
+            season: 2026,
+            round: 1,
+            originalOwnerId: uuid(),
+        });
+
+        expect(result).toBe(id);
+    });
+
+    it("should return null when no matching pick exists", async () => {
+        pickDb.findFirst.mockResolvedValueOnce(null);
+
+        const result = await resolvePickId(pickDb as unknown as ExtendedPrismaClient["draftPick"], {
+            pickType: "HIGHMINORS",
+            season: 2026,
+            round: 5,
+            originalOwnerId: uuid(),
+        });
+
+        expect(result).toBeNull();
     });
 });

--- a/tests/unit/DAO/v2/TradeDAO.test.ts
+++ b/tests/unit/DAO/v2/TradeDAO.test.ts
@@ -4,7 +4,7 @@ import TradeDAO, {
     AcceptedByEntry,
     PrismaTrade,
     buildStaffTradeWhere,
-    resolvePickId,
+    resolvePickIds,
 } from "../../../../src/DAO/v2/TradeDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
 import logger from "../../../../src/bootstrap/logger";
@@ -319,22 +319,42 @@ describe("[PRISMA] TradeDAO", () => {
     describe("getTradesPaginated (extended filters)", () => {
         const tradeA = makeMinimalTrade({ id: uuid() });
 
-        it("should pass playerId filter as tradeItems.some constraint", async () => {
+        it("should pass single playerIds filter as AND tradeItems.some constraint", async () => {
             const playerId = uuid();
             prisma.findMany.mockResolvedValueOnce([tradeA] as any);
             prisma.count.mockResolvedValueOnce(1);
 
-            await dao.getTradesPaginated({ playerId, page: 0, pageSize: 20 });
+            await dao.getTradesPaginated({ playerIds: [playerId], page: 0, pageSize: 20 });
 
             expect(prisma.findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
                     where: expect.objectContaining({
-                        tradeItems: {
-                            some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: playerId },
-                        },
+                        AND: [
+                            {
+                                tradeItems: {
+                                    some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: playerId },
+                                },
+                            },
+                        ],
                     }),
                 })
             );
+        });
+
+        it("should use AND logic for multiple playerIds (trade must involve all)", async () => {
+            const playerA = uuid();
+            const playerB = uuid();
+            prisma.findMany.mockResolvedValueOnce([tradeA] as any);
+            prisma.count.mockResolvedValueOnce(1);
+
+            await dao.getTradesPaginated({ playerIds: [playerA, playerB], page: 0, pageSize: 20 });
+
+            const call = prisma.findMany.mock.calls[0][0] as { where: { AND: unknown[] } };
+            expect(call.where.AND).toHaveLength(2);
+            expect(call.where.AND).toEqual([
+                { tradeItems: { some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: playerA } } },
+                { tradeItems: { some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: playerB } } },
+            ]);
         });
 
         it("should pass date range filter on dateCreated by default", async () => {
@@ -372,10 +392,10 @@ describe("[PRISMA] TradeDAO", () => {
             expect(call.where).not.toHaveProperty("dateCreated");
         });
 
-        it("should resolve pick and filter when pick + pickDb provided", async () => {
+        it("should resolve pick and filter when pick + pickDb provided (full pick)", async () => {
             const pickDb = mockDeep<PrismaClient["draftPick"]>();
-            const resolvedPickId = uuid();
-            pickDb.findFirst.mockResolvedValueOnce({ id: resolvedPickId } as any);
+            const resolvedId = uuid();
+            pickDb.findMany.mockResolvedValueOnce([{ id: resolvedId }] as any);
             prisma.findMany.mockResolvedValueOnce([tradeA] as any);
             prisma.count.mockResolvedValueOnce(1);
 
@@ -388,28 +408,90 @@ describe("[PRISMA] TradeDAO", () => {
                 pickDb as unknown as ExtendedPrismaClient["draftPick"]
             );
 
-            expect(pickDb.findFirst).toHaveBeenCalledTimes(1);
+            expect(pickDb.findMany).toHaveBeenCalledTimes(1);
             expect(prisma.findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
                     where: expect.objectContaining({
-                        tradeItems: expect.objectContaining({
-                            some: expect.objectContaining({
-                                tradeItemType: TradeItemType.PICK,
-                                tradeItemId: resolvedPickId,
-                            }),
-                        }),
+                        AND: [
+                            {
+                                tradeItems: {
+                                    some: { tradeItemType: TradeItemType.PICK, tradeItemId: { in: [resolvedId] } },
+                                },
+                            },
+                        ],
                     }),
                 })
             );
         });
 
-        it("should return empty when pick cannot be resolved", async () => {
+        it("should resolve partial pick (type-only) and use IN filter", async () => {
             const pickDb = mockDeep<PrismaClient["draftPick"]>();
-            pickDb.findFirst.mockResolvedValueOnce(null);
+            const idA = uuid();
+            const idB = uuid();
+            pickDb.findMany.mockResolvedValueOnce([{ id: idA }, { id: idB }] as any);
+            prisma.findMany.mockResolvedValueOnce([tradeA] as any);
+            prisma.count.mockResolvedValueOnce(1);
+
+            await dao.getTradesPaginated(
+                {
+                    pick: { pickType: "HIGHMINORS" },
+                    page: 0,
+                    pageSize: 20,
+                },
+                pickDb as unknown as ExtendedPrismaClient["draftPick"]
+            );
+
+            expect(pickDb.findMany).toHaveBeenCalledTimes(1);
+            const pickCall = pickDb.findMany.mock.calls[0][0] as { where: Record<string, unknown> };
+            expect(pickCall.where).not.toHaveProperty("season");
+            expect(pickCall.where).not.toHaveProperty("round");
+            expect(pickCall.where).not.toHaveProperty("originalOwnerId");
+
+            expect(prisma.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        AND: [
+                            {
+                                tradeItems: {
+                                    some: { tradeItemType: TradeItemType.PICK, tradeItemId: { in: [idA, idB] } },
+                                },
+                            },
+                        ],
+                    }),
+                })
+            );
+        });
+
+        it("should resolve partial pick (type + season) and use IN filter", async () => {
+            const pickDb = mockDeep<PrismaClient["draftPick"]>();
+            const idA = uuid();
+            pickDb.findMany.mockResolvedValueOnce([{ id: idA }] as any);
+            prisma.findMany.mockResolvedValueOnce([tradeA] as any);
+            prisma.count.mockResolvedValueOnce(1);
+
+            await dao.getTradesPaginated(
+                {
+                    pick: { pickType: "MAJORS", season: 2026 },
+                    page: 0,
+                    pageSize: 20,
+                },
+                pickDb as unknown as ExtendedPrismaClient["draftPick"]
+            );
+
+            const pickCall = pickDb.findMany.mock.calls[0][0] as { where: Record<string, unknown> };
+            expect(pickCall.where).toHaveProperty("type", "MAJORS");
+            expect(pickCall.where).toHaveProperty("season", 2026);
+            expect(pickCall.where).not.toHaveProperty("round");
+            expect(pickCall.where).not.toHaveProperty("originalOwnerId");
+        });
+
+        it("should return empty when no picks match partial filter", async () => {
+            const pickDb = mockDeep<PrismaClient["draftPick"]>();
+            pickDb.findMany.mockResolvedValueOnce([]);
 
             const result = await dao.getTradesPaginated(
                 {
-                    pick: { pickType: "MAJORS", season: 2026, round: 99, originalOwnerId: uuid() },
+                    pick: { pickType: "MAJORS", season: 2099 },
                     page: 0,
                     pageSize: 20,
                 },
@@ -429,7 +511,7 @@ describe("[PRISMA] TradeDAO", () => {
                 statuses: [TradeStatus.SUBMITTED],
                 dateFrom: "2026-01-01",
                 dateField: "ACCEPTED",
-                playerId,
+                playerIds: [playerId],
                 page: 0,
                 pageSize: 10,
             });
@@ -437,7 +519,7 @@ describe("[PRISMA] TradeDAO", () => {
             const call = prisma.findMany.mock.calls[0][0] as { where: Record<string, unknown> };
             expect(call.where).toHaveProperty("status", { in: [TradeStatus.SUBMITTED] });
             expect(call.where).toHaveProperty("acceptedOnDate");
-            expect(call.where).toHaveProperty("tradeItems");
+            expect(call.where).toHaveProperty("AND");
         });
     });
 });
@@ -474,44 +556,82 @@ describe("buildStaffTradeWhere", () => {
         expect(where).not.toHaveProperty("dateCreated");
     });
 
-    it("should add playerId as tradeItems.some filter", () => {
+    it("should add single playerIds as AND tradeItems.some filter", () => {
         const pid = uuid();
-        const where = buildStaffTradeWhere({ playerId: pid });
-        expect(where.tradeItems).toEqual({
-            some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: pid },
-        });
+        const where = buildStaffTradeWhere({ playerIds: [pid] });
+        expect(where.AND).toEqual([
+            { tradeItems: { some: { tradeItemType: TradeItemType.PLAYER, tradeItemId: pid } } },
+        ]);
+    });
+
+    it("should use AND logic for multiple playerIds", () => {
+        const pidA = uuid();
+        const pidB = uuid();
+        const where = buildStaffTradeWhere({ playerIds: [pidA, pidB] });
+        expect(where.AND as unknown[]).toHaveLength(2);
+    });
+
+    it("should not add AND clause when playerIds is empty", () => {
+        const where = buildStaffTradeWhere({ playerIds: [] });
+        expect(where).not.toHaveProperty("AND");
     });
 });
 
-describe("resolvePickId", () => {
+describe("resolvePickIds", () => {
     const pickDb = mockDeep<PrismaClient["draftPick"]>();
 
     afterEach(() => mockClear(pickDb));
 
-    it("should return the id when a matching pick exists", async () => {
+    it("should return ids when matching picks exist (full filter)", async () => {
         const id = uuid();
-        pickDb.findFirst.mockResolvedValueOnce({ id } as any);
+        pickDb.findMany.mockResolvedValueOnce([{ id }] as any);
 
-        const result = await resolvePickId(pickDb as unknown as ExtendedPrismaClient["draftPick"], {
+        const result = await resolvePickIds(pickDb as unknown as ExtendedPrismaClient["draftPick"], {
             pickType: "MAJORS",
             season: 2026,
             round: 1,
             originalOwnerId: uuid(),
         });
 
-        expect(result).toBe(id);
+        expect(result).toEqual([id]);
     });
 
-    it("should return null when no matching pick exists", async () => {
-        pickDb.findFirst.mockResolvedValueOnce(null);
+    it("should return empty array when no matching picks exist", async () => {
+        pickDb.findMany.mockResolvedValueOnce([]);
 
-        const result = await resolvePickId(pickDb as unknown as ExtendedPrismaClient["draftPick"], {
+        const result = await resolvePickIds(pickDb as unknown as ExtendedPrismaClient["draftPick"], {
             pickType: "HIGHMINORS",
-            season: 2026,
-            round: 5,
-            originalOwnerId: uuid(),
+            season: 2099,
         });
 
-        expect(result).toBeNull();
+        expect(result).toEqual([]);
+    });
+
+    it("should query only provided fields (partial filter)", async () => {
+        pickDb.findMany.mockResolvedValueOnce([{ id: uuid() }, { id: uuid() }] as any);
+
+        await resolvePickIds(pickDb as unknown as ExtendedPrismaClient["draftPick"], {
+            pickType: "HIGHMINORS",
+        });
+
+        const call = pickDb.findMany.mock.calls[0][0] as { where: Record<string, unknown> };
+        expect(call.where).toHaveProperty("type", "HIGHMINORS");
+        expect(call.where).not.toHaveProperty("season");
+        expect(call.where).not.toHaveProperty("round");
+        expect(call.where).not.toHaveProperty("originalOwnerId");
+    });
+
+    it("should return multiple ids for partial filter (type + season)", async () => {
+        const idA = uuid();
+        const idB = uuid();
+        const idC = uuid();
+        pickDb.findMany.mockResolvedValueOnce([{ id: idA }, { id: idB }, { id: idC }] as any);
+
+        const result = await resolvePickIds(pickDb as unknown as ExtendedPrismaClient["draftPick"], {
+            pickType: "MAJORS",
+            season: 2026,
+        });
+
+        expect(result).toEqual([idA, idB, idC]);
     });
 });


### PR DESCRIPTION
## Summary

- Extend `TradeDAO.getTradesPaginated` with structured filters: date range (on configurable date column), multi-player involvement by UUID array (AND logic, max 10), and draft pick by partial composite key (any combination of type, season, round, original owner — resolved server-side to matching pick IDs via `IN` filter). All filters combine with `AND` alongside existing status and pagination.
- Extend the `trades.listStaff` tRPC Zod input to expose the new filter axes: `playerIds` (array, max 10) replaces `playerId`; pick sub-fields are individually optional with a `.refine()` requiring at least one.
- Add `csvName` to `TeamDAO.ownersSelect` so team list API returns CSV names for owner display.
- Bump `@akosasante/trpc-types` to 1.16.1 with the updated input types.
- Add ADR documenting the decision to use structured Postgres filters (deferring Elasticsearch, tsvector, pg_trgm), caching strategy, and monitoring plan.
- 36 unit tests pass for `TradeDAO`, `buildStaffTradeWhere`, and `resolvePickIds` (including multi-player AND, partial pick type-only, type+season, and empty result scenarios).

## Test plan

- [x] `tsc --noEmit` passes
- [x] `TradeDAO.test.ts` — 36 tests pass, 100% coverage on TradeDAO.ts
- [ ] Integration test with real DB (manual or CI)