### PR TITLE
fix: normalize V3_BASE_URL for trade email magic links

### DIFF
--- a/src/api/routes/MessengerController.ts
+++ b/src/api/routes/MessengerController.ts
@@ -12,7 +12,7 @@ import { getPrismaClientFromRequest } from "../../bootstrap/prisma-db";
 import { extractTraceContext } from "../../utils/tracing";
 import { createTradeActionToken } from "./v2/utils/tradeActionTokens";
 import { tradeActionTokenGeneratedMetric, tradeRequestEmailEnqueuedMetric } from "../../bootstrap/metrics";
-import { shouldUseV3TradeLinkForEmail } from "../../utils/v3TradeLinkEmailAllowlist";
+import { normalizeV3BaseUrl, shouldUseV3TradeLinkForEmail } from "../../utils/v3TradeLinkEmailAllowlist";
 import { getOwnerNotificationPrefs } from "../../utils/userNotificationPrefs";
 
 const TRADE_REQUEST_OWNER_RELATIONS = ["tradeParticipants", "tradeParticipants.team", "tradeParticipants.team.owners"];
@@ -61,7 +61,7 @@ export default class MessengerController {
 
         const traceContext = extractTraceContext() || undefined;
         const baseDomain = process.env.BASE_URL;
-        const v3BaseDomain = process.env.V3_BASE_URL;
+        const v3BaseDomain = normalizeV3BaseUrl(process.env.V3_BASE_URL);
         const notificationSettingsUrl = v3BaseDomain ? `${v3BaseDomain}/dashboard` : undefined;
 
         const recipientOwners = trade.recipients.flatMap(recipTeam => recipTeam.owners ?? []);
@@ -142,7 +142,7 @@ export default class MessengerController {
             }
 
             const traceContext = extractTraceContext() || undefined;
-            const v3BaseDomain = process.env.V3_BASE_URL;
+            const v3BaseDomain = normalizeV3BaseUrl(process.env.V3_BASE_URL);
             const notificationSettingsUrl = v3BaseDomain ? `${v3BaseDomain}/dashboard` : undefined;
 
             const creatorOwnerIds = new Set(trade.creator?.owners?.map(o => o.id).filter(Boolean));
@@ -230,7 +230,7 @@ export default class MessengerController {
 
             const traceContext = extractTraceContext() || undefined;
             const baseDomain = process.env.BASE_URL;
-            const v3BaseDomain = process.env.V3_BASE_URL;
+            const v3BaseDomain = normalizeV3BaseUrl(process.env.V3_BASE_URL);
             const notificationSettingsUrl = v3BaseDomain ? `${v3BaseDomain}/dashboard` : undefined;
 
             const creatorOwners = trade.creator?.owners ?? [];

--- a/src/api/routes/v2/routers/trade.ts
+++ b/src/api/routes/v2/routers/trade.ts
@@ -8,7 +8,7 @@ import { tradeActionTokenGeneratedMetric } from "../../../../bootstrap/metrics";
 import TradeDAO, { AcceptedByEntry, PrismaTrade } from "../../../../DAO/v2/TradeDAO";
 import ObanDAO from "../../../../DAO/v2/ObanDAO";
 import { createTradeActionToken } from "../utils/tradeActionTokens";
-import { shouldUseV3TradeLinkForEmail } from "../../../../utils/v3TradeLinkEmailAllowlist";
+import { normalizeV3BaseUrl, shouldUseV3TradeLinkForEmail } from "../../../../utils/v3TradeLinkEmailAllowlist";
 import { getOwnerNotificationPrefs } from "../../../../utils/userNotificationPrefs";
 import { PublicUser } from "../../../../DAO/v2/UserDAO";
 import type { ExtendedPrismaClient } from "../../../../bootstrap/prisma-db";
@@ -128,7 +128,7 @@ async function enqueueAcceptanceNotifications(
     prisma: ExtendedPrismaClient
 ): Promise<void> {
     const obanDao = new ObanDAO(prisma.obanJob);
-    const v3BaseDomain = process.env.V3_BASE_URL;
+    const v3BaseDomain = normalizeV3BaseUrl(process.env.V3_BASE_URL);
     const notificationSettingsUrl = v3BaseDomain ? `${v3BaseDomain}/dashboard` : undefined;
 
     const creatorOwners = trade.tradeParticipants
@@ -176,7 +176,7 @@ async function enqueueDeclineNotifications(
     prisma: ExtendedPrismaClient
 ): Promise<void> {
     const obanDao = new ObanDAO(prisma.obanJob);
-    const v3BaseDomain = process.env.V3_BASE_URL;
+    const v3BaseDomain = normalizeV3BaseUrl(process.env.V3_BASE_URL);
     const notificationSettingsUrl = v3BaseDomain ? `${v3BaseDomain}/dashboard` : undefined;
 
     const creatorOwnerIdSet = new Set(

--- a/src/email/mailer.ts
+++ b/src/email/mailer.ts
@@ -15,7 +15,7 @@ import { rollbar } from "../bootstrap/rollbar";
 import EmailDAO from "../DAO/EmailDAO";
 import DbEmail from "../models/email";
 import { createTradeActionToken } from "../api/routes/v2/utils/tradeActionTokens";
-import { shouldUseV3TradeLinkForEmail } from "../utils/v3TradeLinkEmailAllowlist";
+import { normalizeV3BaseUrl, shouldUseV3TradeLinkForEmail } from "../utils/v3TradeLinkEmailAllowlist";
 
 export interface SendInBlueSendResponse {
     envelope: {
@@ -50,7 +50,7 @@ const sendInBlueTransport = nodemailer.createTransport({
 });
 
 const baseDomain = process.env.BASE_URL;
-const v3BaseDomain = process.env.V3_BASE_URL;
+const v3BaseDomain = normalizeV3BaseUrl(process.env.V3_BASE_URL);
 
 function getTitleText(trade: Trade) {
     if (trade.tradeParticipants?.length === 2) {

--- a/src/utils/v3TradeLinkEmailAllowlist.ts
+++ b/src/utils/v3TradeLinkEmailAllowlist.ts
@@ -36,12 +36,23 @@ export function resetV3TradeLinkEmailAllowlistCacheForTests(): void {
 }
 
 /**
+ * Trim and strip trailing slashes from V3_BASE_URL so `${base}/trades/...` never becomes `//trades/...`.
+ */
+export function normalizeV3BaseUrl(raw: string | undefined): string | undefined {
+    const t = raw?.trim();
+    if (!t) {
+        return undefined;
+    }
+    return t.replace(/\/+$/, "");
+}
+
+/**
  * True when this recipient should get V3 URLs in trade emails (tokens, /trades/...).
  * False when USE_V3_TRADE_LINKS or V3_BASE_URL is off, email missing, allowlist is unset/empty,
  * or the address is not allowlisted. Allowlist entry "*" alone matches any non-empty email.
  */
 export function shouldUseV3TradeLinkForEmail(email: string | null | undefined): boolean {
-    if (process.env.USE_V3_TRADE_LINKS !== "true" || !process.env.V3_BASE_URL?.trim()) {
+    if (process.env.USE_V3_TRADE_LINKS !== "true" || !normalizeV3BaseUrl(process.env.V3_BASE_URL)) {
         return false;
     }
     const normalized = email?.trim().toLowerCase();

--- a/tests/unit/utils/v3TradeLinkEmailAllowlist.test.ts
+++ b/tests/unit/utils/v3TradeLinkEmailAllowlist.test.ts
@@ -1,4 +1,5 @@
 import {
+    normalizeV3BaseUrl,
     resetV3TradeLinkEmailAllowlistCacheForTests,
     shouldUseV3TradeLinkForEmail,
 } from "../../../src/utils/v3TradeLinkEmailAllowlist";
@@ -21,6 +22,20 @@ describe("v3TradeLinkEmailAllowlist", () => {
         process.env.USE_V3_TRADE_LINKS = "true";
         delete process.env.V3_BASE_URL;
         expect(shouldUseV3TradeLinkForEmail("a@example.com")).toBe(false);
+    });
+
+    it("treats V3_BASE_URL with only whitespace as missing", () => {
+        process.env.USE_V3_TRADE_LINKS = "true";
+        process.env.V3_BASE_URL = "   ";
+        expect(shouldUseV3TradeLinkForEmail("a@example.com")).toBe(false);
+    });
+
+    it("accepts V3_BASE_URL with trailing slashes for allowlist gating", () => {
+        process.env.USE_V3_TRADE_LINKS = "true";
+        process.env.V3_BASE_URL = "https://v3.example///";
+        process.env.V3_TRADE_LINK_EMAIL_ALLOWLIST = "*";
+        resetV3TradeLinkEmailAllowlistCacheForTests();
+        expect(shouldUseV3TradeLinkForEmail("a@example.com")).toBe(true);
     });
 
     it("returns false for empty email", () => {
@@ -53,5 +68,18 @@ describe("v3TradeLinkEmailAllowlist", () => {
         expect(shouldUseV3TradeLinkForEmail("beta@example.com")).toBe(true);
         expect(shouldUseV3TradeLinkForEmail("other@x.test")).toBe(true);
         expect(shouldUseV3TradeLinkForEmail("nope@example.com")).toBe(false);
+    });
+});
+
+describe("normalizeV3BaseUrl", () => {
+    it("returns undefined for empty input", () => {
+        expect(normalizeV3BaseUrl(undefined)).toBeUndefined();
+        expect(normalizeV3BaseUrl("")).toBeUndefined();
+        expect(normalizeV3BaseUrl("  ")).toBeUndefined();
+    });
+
+    it("strips trailing slashes and whitespace", () => {
+        expect(normalizeV3BaseUrl("https://ffftemp.akosua.xyz/")).toBe("https://ffftemp.akosua.xyz");
+        expect(normalizeV3BaseUrl("  https://x.test///  ")).toBe("https://x.test");
     });
 });


### PR DESCRIPTION
## Problem

If `V3_BASE_URL` is set with a **trailing slash** (e.g. `https://ffftemp.akosua.xyz/`), string templates such as `` `${v3BaseDomain}/trades/${id}?...` `` produced **`//trades/...`** in outbound email links. That path does not match the V3 router (`/trades/:id`), which led to confusing fallbacks and broken navigation toward the legacy client.

## Solution

- Introduce **`normalizeV3BaseUrl()`**: trim whitespace and remove trailing slashes before any URL is built.
- Use it everywhere trade emails / notifications build V3 links: **`mailer.ts`**, **`MessengerController.ts`**, and **`trade.ts`** (tRPC enqueue paths).
- **`shouldUseV3TradeLinkForEmail`** now treats “V3 configured” using the same normalized value so behavior matches link construction.

## Tests

- Extended **`v3TradeLinkEmailAllowlist.test.ts`**: empty/whitespace base, trailing slashes with allowlist `*`, and dedicated **`normalizeV3BaseUrl`** cases.

## Verification

- `make typecheck && make lint`
- `npx prettier --check` on touched files
- `make test-ci-unit` (and targeted Jest run for the allowlist test file)
