### PR TITLE
feat: V3 UI beta session (v3UiBeta + SSO token exchange + Netlify cookies)

### DIFF
--- a/src/api/middlewares/CookieDomainHandler.ts
+++ b/src/api/middlewares/CookieDomainHandler.ts
@@ -1,10 +1,14 @@
-import { Request } from "express";
+import { Request, Response } from "express";
+import type { Session } from "express-session";
 import logger from "../../bootstrap/logger";
 
-/**
- * Allowed Netlify origins that should have cookies set with .netlify.app domain
- */
-const ALLOWED_NETLIFY_ORIGINS = ["https://staging--ffftemp.netlify.app", "https://ffftemp.akosua.xyz"] as const;
+/** Must match getSessionCookieName() in bootstrap/express.ts */
+function getSessionCookieNameForPatch(): string {
+    return process.env.APP_ENV === "staging" ? "staging_trades.sid" : "trades.sid";
+}
+
+/** V3 beta on this hostname uses the same cookie-domain stripping as Netlify previews. */
+const ALLOWED_AKOSUA_UI_ORIGINS = ["https://ffftemp.akosua.xyz"] as const;
 
 /**
  * Extract origin from a URL string.
@@ -23,8 +27,24 @@ function extractOriginFromUrl(url: string): string | null {
     }
 }
 
+function isHttpsNetlifyAppOrigin(extractedOrigin: string): boolean {
+    try {
+        const u = new URL(extractedOrigin);
+        return u.protocol === "https:" && u.hostname.endsWith(".netlify.app");
+    } catch {
+        return false;
+    }
+}
+
+function originNeedsNetlifyStyleSessionCookie(extractedOrigin: string): boolean {
+    return (
+        (ALLOWED_AKOSUA_UI_ORIGINS as readonly string[]).includes(extractedOrigin) ||
+        isHttpsNetlifyAppOrigin(extractedOrigin)
+    );
+}
+
 /**
- * Check if the request origin matches one of the allowed Netlify origins.
+ * Check if the request origin should use Netlify-style session cookies (strip Domain on Set-Cookie).
  *
  * @param req Express request object
  * @returns true if the origin matches an allowed Netlify origin, false otherwise
@@ -34,11 +54,8 @@ export function isNetlifyOrigin(req: Request): boolean {
     const origin = req.get("Origin");
     if (origin) {
         const extractedOrigin = extractOriginFromUrl(origin);
-        if (
-            extractedOrigin &&
-            (ALLOWED_NETLIFY_ORIGINS[0] === extractedOrigin || ALLOWED_NETLIFY_ORIGINS[1] === extractedOrigin)
-        ) {
-            logger.debug(`Detected Netlify origin from Origin header: ${extractedOrigin}`);
+        if (extractedOrigin && originNeedsNetlifyStyleSessionCookie(extractedOrigin)) {
+            logger.debug(`Detected Netlify-style UI origin from Origin header: ${extractedOrigin}`);
             return true;
         }
         // If Origin header exists but doesn't match, return false immediately
@@ -50,14 +67,54 @@ export function isNetlifyOrigin(req: Request): boolean {
     const referer = req.get("Referer");
     if (referer) {
         const extractedOrigin = extractOriginFromUrl(referer);
-        if (
-            extractedOrigin &&
-            (ALLOWED_NETLIFY_ORIGINS[0] === extractedOrigin || ALLOWED_NETLIFY_ORIGINS[1] === extractedOrigin)
-        ) {
-            logger.debug(`Detected Netlify origin from Referer header: ${extractedOrigin}`);
+        if (extractedOrigin && originNeedsNetlifyStyleSessionCookie(extractedOrigin)) {
+            logger.debug(`Detected Netlify-style UI origin from Referer header: ${extractedOrigin}`);
             return true;
         }
     }
 
     return false;
+}
+
+/**
+ * When the V3 UI is hosted on Netlify (*.netlify.app) or the beta akosua host, browsers can reject
+ * session cookies that still carry Domain=.akosua.xyz from the API. Patch outgoing Set-Cookie headers
+ * to drop Domain (host-only on the API), matching auth.login.
+ */
+export function applyNetlifySessionCookieHeaderPatch(req: Request, res: Response): void {
+    if (!isNetlifyOrigin(req)) {
+        return;
+    }
+    const cookieName = getSessionCookieNameForPatch();
+    const originalSetHeader = res.setHeader.bind(res);
+    res.setHeader = function (name: string, value: string | string[]) {
+        if (name.toLowerCase() === "set-cookie") {
+            const cookies = Array.isArray(value) ? value : [value];
+            const modifiedCookies = cookies.map(cookie => {
+                if (cookie.includes(cookieName)) {
+                    const modified = cookie.replace(/;\s*Domain=[^;]*/gi, "");
+                    logger.debug(
+                        `Removed Domain attribute from Set-Cookie header for Netlify-style origin: ${cookieName}`
+                    );
+                    return modified;
+                }
+                return cookie;
+            });
+            return originalSetHeader(name, modifiedCookies);
+        }
+        return originalSetHeader(name, value);
+    };
+}
+
+export function saveExpressSession(session: Session): Promise<void> {
+    return new Promise((resolve, reject) => {
+        session.save(err => {
+            if (err) {
+                logger.error("Could not save session:", err);
+                reject(new Error("Could not save session"));
+            } else {
+                resolve();
+            }
+        });
+    });
 }

--- a/src/api/routes/AuthController.ts
+++ b/src/api/routes/AuthController.ts
@@ -32,6 +32,7 @@ import {
     extractTraceContext,
 } from "../../utils/tracing";
 import { context } from "@opentelemetry/api";
+import { isV3UiBetaAllowlistedEmail } from "../../utils/v3TradeLinkEmailAllowlist";
 
 // declare the additional fields that we add to express session (via routing-controllers)
 declare module "express-session" {
@@ -297,9 +298,11 @@ export default class AuthController {
     }
 
     @Get("/session_check")
-    public sessionCheck(@CurrentUser({ required: true }) user: PublicUser): Promise<PublicUser> {
+    public sessionCheck(
+        @CurrentUser({ required: true }) user: PublicUser
+    ): Promise<PublicUser & { v3UiBeta: boolean }> {
         logger.debug(`session check worked ${user}`);
         // rollbar.info("sessionCheck", { user });
-        return Promise.resolve(user);
+        return Promise.resolve({ ...user, v3UiBeta: isV3UiBetaAllowlistedEmail(user.email) });
     }
 }

--- a/src/api/routes/v2/routers/auth.ts
+++ b/src/api/routes/v2/routers/auth.ts
@@ -18,6 +18,7 @@ import { PublicUser } from "../../../../DAO/v2/UserDAO";
 import { isNetlifyOrigin } from "../../../middlewares/CookieDomainHandler";
 import { getSessionCookieName } from "../../../../bootstrap/express";
 import { destroyAllUserSessions, registerUserSession } from "../utils/ssoTokens";
+import { isV3UiBetaAllowlistedEmail } from "../../../../utils/v3TradeLinkEmailAllowlist";
 
 // Input validation schemas
 const emailSchema = z.object({
@@ -308,7 +309,7 @@ export const authRouter = router({
 
             logger.debug(`tRPC session check worked for user ${user.id}`);
 
-            return user;
+            return { ...user, v3UiBeta: isV3UiBetaAllowlistedEmail(user.email) };
         })
     ),
     logout: publicProcedure.mutation(

--- a/src/api/routes/v2/routers/auth.ts
+++ b/src/api/routes/v2/routers/auth.ts
@@ -118,7 +118,7 @@ export const authRouter = router({
                 applyNetlifySessionCookieHeaderPatch(ctx.req, ctx.res);
 
                 // Save session and increment metrics
-                await saveExpressSession(ctx.session!);
+                await saveExpressSession(ctx.session);
 
                 await registerUserSession(serializeUser(authenticatedUser)!, ctx.req.sessionID);
 

--- a/src/api/routes/v2/routers/auth.ts
+++ b/src/api/routes/v2/routers/auth.ts
@@ -15,8 +15,11 @@ import {
 } from "../../../../authentication/auth";
 import { activeUserMetric, activeSessionsMetric } from "../../../../bootstrap/metrics";
 import { PublicUser } from "../../../../DAO/v2/UserDAO";
-import { isNetlifyOrigin } from "../../../middlewares/CookieDomainHandler";
-import { getSessionCookieName } from "../../../../bootstrap/express";
+import {
+    applyNetlifySessionCookieHeaderPatch,
+    isNetlifyOrigin,
+    saveExpressSession,
+} from "../../../middlewares/CookieDomainHandler";
 import { destroyAllUserSessions, registerUserSession } from "../utils/ssoTokens";
 import { isV3UiBetaAllowlistedEmail } from "../../../../utils/v3TradeLinkEmailAllowlist";
 
@@ -111,55 +114,15 @@ export const authRouter = router({
                 ctx.session.user = serializeUser(authenticatedUser);
                 setSessionUserContext(ctx.session, authenticatedUser);
 
-                // If request is from a Netlify origin, intercept and modify the Set-Cookie header
-                // that express-session will set after session.save()
-                const isNetlify = isNetlifyOrigin(ctx.req);
-                const cookieName = getSessionCookieName();
-
-                // Intercept Set-Cookie header if this is a Netlify origin
-                if (isNetlify) {
-                    const originalSetHeader = ctx.res.setHeader.bind(ctx.res);
-                    ctx.res.setHeader = function (name: string, value: string | string[]) {
-                        if (name.toLowerCase() === "set-cookie") {
-                            // Modify the Set-Cookie header to remove Domain attribute for Netlify origins
-                            // Browsers reject cookies with Domain=.netlify.app (public suffix)
-                            // By removing the Domain attribute, the cookie is scoped to the exact origin
-                            // (e.g., staging--ffftemp.netlify.app), which browsers will accept
-                            const cookies = Array.isArray(value) ? value : [value];
-                            const modifiedCookies = cookies.map(cookie => {
-                                if (cookie.includes(cookieName)) {
-                                    // Remove existing Domain attribute entirely
-                                    // This scopes the cookie to the exact origin (e.g., staging--ffftemp.netlify.app)
-                                    const modified = cookie.replace(/;\s*Domain=[^;]*/gi, "");
-                                    logger.debug(
-                                        `Removed Domain attribute from Set-Cookie header for Netlify origin: ${cookieName}`
-                                    );
-                                    return modified;
-                                }
-                                return cookie;
-                            });
-                            return originalSetHeader(name, modifiedCookies);
-                        }
-                        return originalSetHeader(name, value);
-                    };
-                }
+                // Netlify / cross-site UI: strip Domain on Set-Cookie so the browser keeps the session cookie.
+                applyNetlifySessionCookieHeaderPatch(ctx.req, ctx.res);
 
                 // Save session and increment metrics
-                await new Promise<void>((resolve, reject) => {
-                    ctx.session!.save((sessionErr: Error | null) => {
-                        if (sessionErr) {
-                            logger.error("Could not save session:", sessionErr);
-                            reject(new Error("Could not save session"));
-                        } else {
-                            resolve();
-                        }
-                    });
-                });
+                await saveExpressSession(ctx.session!);
 
                 await registerUserSession(serializeUser(authenticatedUser)!, ctx.req.sessionID);
 
-                // Log that we modified the cookie for Netlify origins
-                if (isNetlify) {
+                if (isNetlifyOrigin(ctx.req)) {
                     addSpanAttributes({
                         "cookie.domain": "none (origin-scoped)",
                         "cookie.set_for_netlify": true,

--- a/src/api/routes/v2/routers/client.ts
+++ b/src/api/routes/v2/routers/client.ts
@@ -22,10 +22,7 @@ import {
 import { consumeTradeActionToken } from "../utils/tradeActionTokens";
 import { TRPCError } from "@trpc/server";
 import "../../../../types/session.types";
-import {
-    applyNetlifySessionCookieHeaderPatch,
-    saveExpressSession,
-} from "../../../middlewares/CookieDomainHandler";
+import { applyNetlifySessionCookieHeaderPatch, saveExpressSession } from "../../../middlewares/CookieDomainHandler";
 
 export const clientRouter = router({
     getIP: publicProcedure.query(

--- a/src/api/routes/v2/routers/client.ts
+++ b/src/api/routes/v2/routers/client.ts
@@ -28,21 +28,31 @@ export const clientRouter = router({
         withTracing("trpc.client.getIP", async (input, ctx, _span) => {
             addSpanEvent("get_ip.start");
 
-            // Extract IP from headers set by reverse proxies or direct connection
+            // Extract IP from headers set by reverse proxies or direct connection.
+            // Cloudflare (and some other CDNs) set CF-Connecting-IP to the end-user address; without it,
+            // the TCP peer is often a Cloudflare POP (e.g. 104.30.x.x), which breaks IP allowlists.
+            const cfConnectingIp = ctx.req.headers["cf-connecting-ip"];
             const xForwardedFor = ctx.req.headers["x-forwarded-for"];
             const xRealIp = ctx.req.headers["x-real-ip"];
             const remoteAddress = ctx.req.connection?.remoteAddress || ctx.req.socket?.remoteAddress;
 
-            // Determine the client IP following standard proxy header precedence
             let clientIP: string;
+            let ipSource: "cf-connecting-ip" | "x-forwarded-for" | "x-real-ip" | "direct";
 
-            if (xForwardedFor) {
+            if (cfConnectingIp) {
+                const raw = Array.isArray(cfConnectingIp) ? cfConnectingIp[0] : cfConnectingIp;
+                clientIP = raw.trim();
+                ipSource = "cf-connecting-ip";
+            } else if (xForwardedFor) {
                 // x-forwarded-for can contain multiple IPs, take the first one (original client)
                 clientIP = Array.isArray(xForwardedFor) ? xForwardedFor[0] : xForwardedFor.split(",")[0].trim();
+                ipSource = "x-forwarded-for";
             } else if (xRealIp) {
                 clientIP = Array.isArray(xRealIp) ? xRealIp[0] : xRealIp;
+                ipSource = "x-real-ip";
             } else {
                 clientIP = remoteAddress || "unknown";
+                ipSource = "direct";
             }
 
             // Normalize IPv6-mapped IPv4 addresses (e.g., ::ffff:192.168.1.1 -> 192.168.1.1)
@@ -52,13 +62,13 @@ export const clientRouter = router({
 
             addSpanAttributes({
                 "client.ip": clientIP,
-                "client.ip_source": xForwardedFor ? "x-forwarded-for" : xRealIp ? "x-real-ip" : "direct",
-                "client.has_proxy_headers": !!(xForwardedFor || xRealIp),
+                "client.ip_source": ipSource,
+                "client.has_proxy_headers": !!(cfConnectingIp || xForwardedFor || xRealIp),
             });
 
             addSpanEvent("get_ip.success", {
                 ip: clientIP,
-                source: xForwardedFor ? "x-forwarded-for" : xRealIp ? "x-real-ip" : "direct",
+                source: ipSource,
             });
 
             logger.debug(`Client IP detected: ${clientIP}`);

--- a/src/api/routes/v2/routers/client.ts
+++ b/src/api/routes/v2/routers/client.ts
@@ -22,6 +22,10 @@ import {
 import { consumeTradeActionToken } from "../utils/tradeActionTokens";
 import { TRPCError } from "@trpc/server";
 import "../../../../types/session.types";
+import {
+    applyNetlifySessionCookieHeaderPatch,
+    saveExpressSession,
+} from "../../../middlewares/CookieDomainHandler";
 
 export const clientRouter = router({
     getIP: publicProcedure.query(
@@ -179,6 +183,10 @@ export const clientRouter = router({
                 ctx.req.session.user = serializeUser(user);
                 setSessionUserContext(ctx.req.session, user);
 
+                // Match auth.login: persist session + Netlify-style Set-Cookie so the browser keeps the cookie
+                applyNetlifySessionCookieHeaderPatch(ctx.req, ctx.res);
+                await saveExpressSession(ctx.req.session);
+
                 await registerUserSession(user.id!, ctx.req.sessionID);
 
                 addSpanAttributes({
@@ -256,6 +264,10 @@ export const clientRouter = router({
 
                 ctx.req.session.user = serializeUser(user);
                 setSessionUserContext(ctx.req.session, user);
+
+                applyNetlifySessionCookieHeaderPatch(ctx.req, ctx.res);
+                await saveExpressSession(ctx.req.session);
+
                 await registerUserSession(user.id!, ctx.req.sessionID);
 
                 addSpanAttributes({

--- a/src/api/routes/v2/utils/ssoTokens.ts
+++ b/src/api/routes/v2/utils/ssoTokens.ts
@@ -27,6 +27,7 @@ const ALLOWED_REDIRECT_HOSTS = new Set([
     "https://staging--ffftemp.netlify.app",
     "http://localhost:3030",
     "http://localhost:3031",
+    "http://localhost:5173",
 ]);
 
 export const SSO_CONFIG = {

--- a/src/utils/v3TradeLinkEmailAllowlist.ts
+++ b/src/utils/v3TradeLinkEmailAllowlist.ts
@@ -51,6 +51,25 @@ export function normalizeV3BaseUrl(raw: string | undefined): string | undefined 
  * False when USE_V3_TRADE_LINKS or V3_BASE_URL is off, email missing, allowlist is unset/empty,
  * or the address is not allowlisted. Allowlist entry "*" alone matches any non-empty email.
  */
+/**
+ * Whether this email appears on `V3_TRADE_LINK_EMAIL_ALLOWLIST` (same parsing as trade-email V3 links: `*`, comma-separated, case-insensitive).
+ * Does **not** require `USE_V3_TRADE_LINKS` or `V3_BASE_URL` — use for UI beta / redirect eligibility independent of email-sending flags.
+ */
+export function isV3UiBetaAllowlistedEmail(email: string | null | undefined): boolean {
+    const allowlist = getAllowlist();
+    if (allowlist === null) {
+        return false;
+    }
+    const normalized = email?.trim().toLowerCase();
+    if (!normalized) {
+        return false;
+    }
+    if (allowlist.has("*")) {
+        return true;
+    }
+    return allowlist.has(normalized);
+}
+
 export function shouldUseV3TradeLinkForEmail(email: string | null | undefined): boolean {
     if (process.env.USE_V3_TRADE_LINKS !== "true" || !normalizeV3BaseUrl(process.env.V3_BASE_URL)) {
         return false;

--- a/tests/unit/api/middlewares/CookieDomainHandler.test.ts
+++ b/tests/unit/api/middlewares/CookieDomainHandler.test.ts
@@ -3,6 +3,19 @@ import { isNetlifyOrigin } from "../../../../src/api/middlewares/CookieDomainHan
 
 describe("CookieDomainHandler", () => {
     describe("isNetlifyOrigin", () => {
+        it("should return true for arbitrary https://*.netlify.app deploy preview from Origin header", () => {
+            const mockReq = {
+                get: jest.fn((header: string) => {
+                    if (header === "Origin") {
+                        return "https://naughty-wozniak-9fc262.netlify.app";
+                    }
+                    return undefined;
+                }),
+            } as unknown as Request;
+
+            expect(isNetlifyOrigin(mockReq)).toBe(true);
+        });
+
         it("should return true for https://staging--ffftemp.netlify.app from Origin header", () => {
             const mockReq = {
                 get: jest.fn((header: string) => {

--- a/tests/unit/api/routes/v2/trpc/auth.test.ts
+++ b/tests/unit/api/routes/v2/trpc/auth.test.ts
@@ -8,6 +8,7 @@ import UserDAO, { PublicUser } from "../../../../../../src/DAO/v2/UserDAO";
 import ObanDAO from "../../../../../../src/DAO/v2/ObanDAO";
 import { Request, Response } from "express";
 import { hashSync } from "bcryptjs";
+import { resetV3TradeLinkEmailAllowlistCacheForTests } from "../../../../../../src/utils/v3TradeLinkEmailAllowlist";
 
 // Mock the tracing utilities
 jest.mock("../../../../../../src/utils/tracing", () => ({
@@ -478,6 +479,13 @@ describe("[TRPC] Auth Router Unit Tests", () => {
     });
 
     describe("sessionCheck", () => {
+        const prevEnv = { ...process.env };
+
+        afterEach(() => {
+            process.env = { ...prevEnv };
+            resetV3TradeLinkEmailAllowlistCacheForTests();
+        });
+
         it("should return user when session exists", async () => {
             const mockUser = {
                 id: "user-123",
@@ -490,11 +498,35 @@ describe("[TRPC] Auth Router Unit Tests", () => {
 
             mockUserDao.getUserById.mockResolvedValue(mockUser);
 
+            process.env.V3_TRADE_LINK_EMAIL_ALLOWLIST = "test@example.com";
+            resetV3TradeLinkEmailAllowlistCacheForTests();
+
             const result = await caller.sessionCheck();
 
             expect(result).toBeDefined();
             expect(result.id).toBe("user-123");
+            expect((result as { v3UiBeta?: boolean }).v3UiBeta).toBe(true);
             expect(mockUserDao.getUserById).toHaveBeenCalledWith("user-123");
+        });
+
+        it("should set v3UiBeta false when email is not on V3_TRADE_LINK_EMAIL_ALLOWLIST", async () => {
+            const mockUser = {
+                id: "user-456",
+                email: "other@example.com",
+                isAdmin: () => false,
+            } as unknown as PublicUser;
+
+            const mockSession = { user: "user-456" };
+            const caller = createCallerFactory(authRouter)(createMockContext(mockSession));
+
+            mockUserDao.getUserById.mockResolvedValue(mockUser);
+
+            process.env.V3_TRADE_LINK_EMAIL_ALLOWLIST = "test@example.com";
+            resetV3TradeLinkEmailAllowlistCacheForTests();
+
+            const result = await caller.sessionCheck();
+
+            expect((result as { v3UiBeta?: boolean }).v3UiBeta).toBe(false);
         });
 
         it("should throw UNAUTHORIZED error when no session exists", async () => {

--- a/tests/unit/api/routes/v2/trpc/client.test.ts
+++ b/tests/unit/api/routes/v2/trpc/client.test.ts
@@ -85,16 +85,20 @@ describe("[TRPC] Client Router Unit Tests", () => {
             origin: headers.origin || `https://${finalHostname}`,
         };
 
+        const header = (name: string) => {
+            const value = finalHeaders[name.toLowerCase()];
+            if (Array.isArray(value)) {
+                return value[0];
+            }
+            return value as string | undefined;
+        };
+
         const req = {
             ...mockReq,
             headers: finalHeaders,
-            header: (name: string) => {
-                const value = finalHeaders[name.toLowerCase()];
-                if (Array.isArray(value)) {
-                    return value[0];
-                }
-                return value as string | undefined;
-            },
+            header,
+            // Express aliases `get` to the same header lookup; CookieDomainHandler uses req.get().
+            get: (name: string) => header(name),
             connection: { remoteAddress: "192.168.1.100" },
             socket: { remoteAddress: "192.168.1.100" },
             sessionID: "test-session-id",
@@ -596,10 +600,11 @@ describe("[TRPC] Client Router Unit Tests", () => {
             mockSsoTokens.consumeTransferToken.mockResolvedValue(validTokenPayload);
 
             const mockContext = createMockContext({}, undefined, "ffftemp.akosua.xyz");
-            mockContext.req.session = {
-                regenerate: jest.fn(callback => callback()),
+            // Keep full session shape (save, cookie, etc.); only override fields under test.
+            Object.assign(mockContext.req.session, {
+                regenerate: jest.fn(callback => callback(null)),
                 user: undefined,
-            } as any;
+            });
 
             const caller = createCallerFactory(clientRouter)(mockContext);
 

--- a/tests/unit/api/routes/v2/trpc/client.test.ts
+++ b/tests/unit/api/routes/v2/trpc/client.test.ts
@@ -148,6 +148,49 @@ describe("[TRPC] Client Router Unit Tests", () => {
     });
 
     describe("getIP", () => {
+        it("should prefer cf-connecting-ip over x-forwarded-for (Cloudflare)", async () => {
+            const caller = createCallerFactory(clientRouter)(
+                createMockContext({
+                    "cf-connecting-ip": "203.0.113.9",
+                    "x-forwarded-for": "198.51.100.1",
+                })
+            );
+
+            const result = await caller.getIP();
+
+            expect(result).toEqual({
+                ip: "203.0.113.9",
+            });
+        });
+
+        it("should extract IP from cf-connecting-ip when present alone", async () => {
+            const caller = createCallerFactory(clientRouter)(
+                createMockContext({
+                    "cf-connecting-ip": " 203.0.113.2 ",
+                })
+            );
+
+            const result = await caller.getIP();
+
+            expect(result).toEqual({
+                ip: "203.0.113.2",
+            });
+        });
+
+        it("should handle cf-connecting-ip as array", async () => {
+            const caller = createCallerFactory(clientRouter)(
+                createMockContext({
+                    "cf-connecting-ip": ["203.0.113.3"],
+                })
+            );
+
+            const result = await caller.getIP();
+
+            expect(result).toEqual({
+                ip: "203.0.113.3",
+            });
+        });
+
         it("should extract IP from x-forwarded-for header (single IP)", async () => {
             const caller = createCallerFactory(clientRouter)(
                 createMockContext({

--- a/tests/unit/utils/v3TradeLinkEmailAllowlist.test.ts
+++ b/tests/unit/utils/v3TradeLinkEmailAllowlist.test.ts
@@ -1,4 +1,5 @@
 import {
+    isV3UiBetaAllowlistedEmail,
     normalizeV3BaseUrl,
     resetV3TradeLinkEmailAllowlistCacheForTests,
     shouldUseV3TradeLinkForEmail,
@@ -68,6 +69,37 @@ describe("v3TradeLinkEmailAllowlist", () => {
         expect(shouldUseV3TradeLinkForEmail("beta@example.com")).toBe(true);
         expect(shouldUseV3TradeLinkForEmail("other@x.test")).toBe(true);
         expect(shouldUseV3TradeLinkForEmail("nope@example.com")).toBe(false);
+    });
+});
+
+describe("isV3UiBetaAllowlistedEmail", () => {
+    const prev = { ...process.env };
+
+    afterEach(() => {
+        process.env = { ...prev };
+        resetV3TradeLinkEmailAllowlistCacheForTests();
+    });
+
+    it("returns false when allowlist env is unset", () => {
+        delete process.env.V3_TRADE_LINK_EMAIL_ALLOWLIST;
+        resetV3TradeLinkEmailAllowlistCacheForTests();
+        expect(isV3UiBetaAllowlistedEmail("a@example.com")).toBe(false);
+    });
+
+    it("returns true for any non-empty email when allowlist is * (ignores USE_V3_TRADE_LINKS)", () => {
+        delete process.env.USE_V3_TRADE_LINKS;
+        delete process.env.V3_BASE_URL;
+        process.env.V3_TRADE_LINK_EMAIL_ALLOWLIST = "*";
+        resetV3TradeLinkEmailAllowlistCacheForTests();
+        expect(isV3UiBetaAllowlistedEmail("Anyone@Example.COM")).toBe(true);
+    });
+
+    it("matches listed emails case-insensitively without USE_V3_TRADE_LINKS", () => {
+        delete process.env.USE_V3_TRADE_LINKS;
+        process.env.V3_TRADE_LINK_EMAIL_ALLOWLIST = " Beta@Example.com ";
+        resetV3TradeLinkEmailAllowlistCacheForTests();
+        expect(isV3UiBetaAllowlistedEmail("beta@example.com")).toBe(true);
+        expect(isV3UiBetaAllowlistedEmail("nope@example.com")).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Summary

Backend support for **V3 UI beta** and **cross-app SSO**: session payloads expose **`v3UiBeta`**, short-lived **redirect tokens** tie a logged-in session to a one-time exchange on another origin, and **session cookies** persist correctly for **Netlify** / cross-site browsers.

## Session / allowlist

- **`isV3UiBetaAllowlistedEmail()`** (`v3TradeLinkEmailAllowlist.ts`): parses **`V3_TRADE_LINK_EMAIL_ALLOWLIST`** (same rules as trade-email magic links).
- **`auth.sessionCheck`** (tRPC) and **`GET /auth/session_check`** (REST): return **`{ …user, v3UiBeta: boolean }`** so the V2 SPA can redirect allowlisted testers without IP match.

## SSO token exchange

- **`client.createRedirectToken`** (protected): stores **`sessionId` + `userId`** in Redis; validates **`redirectTo`** / **`origin`** against **`ALLOWED_REDIRECT_HOSTS`** (includes staging, Netlify previews, localhost dev ports).
- **`client.exchangeRedirectToken`**: loads original session, **`session.regenerate()`**, copies user, **`registerUserSession`**, returns user payload.
- **`client.exchangeTradeActionToken`**: same **cookie + `session.save()`** behavior where applicable.

## Netlify / cross-site cookies

- **`applyNetlifySessionCookieHeaderPatch`** + **`saveExpressSession`**: shared with **`auth.login`** — strip **`Domain=`** from **`Set-Cookie`** for **`https://*.netlify.app`** (and beta host) and **persist session** after exchange so the browser keeps the cookie.
- **`CookieDomainHandler`**: treat any **`https://*.netlify.app`** origin like the previous hard-coded preview URL.

## Other (same branch)

- **`getIP`**: prefer **`CF-Connecting-IP`** when behind Cloudflare (reduces “IP not allowed for new client” from POP IPs).
- **SSO allowlist**: e.g. **`http://localhost:5173`** for local V3.
- **Lint**: small ESLint/Prettier fixes on touched files.

## Companion PRs

- **V2 client:** https://github.com/akosasante/TradeMachineClient/pull/120  
- **V3 client:** https://github.com/akosasante/NewTradeMachineClient/pull/12  

## Tests

- Unit / integration around **`v3UiBeta`**, **`exchangeRedirectToken`**, cookie handler, and related auth paths (see CI).
