### PR TITLE
docs + test infra: docs/ structure, ADR 0003, shared v2 DAO test helpers & testing guide

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,6 @@ dist
 coverage
 # don't lint AI plans directory
 ai_plans
+# don't lint documentation (may contain reference .ts snippets that aren't part of the build)
+docs
 

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ workspace.code-workspace
 trade.iml
 
 **/.claude/settings.local.json
-ai_plans
 TradeMachineElixirApp
 TradeMachineElixirApp/
 TradeMachineElixirApp/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,14 @@ This file provides guidance to AI Assistants when working with code in this repo
 
 ## Project Documentation (`docs/`)
 
-Longer-form documentation lives in [`docs/`](./docs/README.md): **Architecture Decision Records** in [`docs/adr/`](./docs/adr/README.md) and **proposals / plans / analyses** in [`docs/proposals-and-projects/`](./docs/proposals-and-projects/README.md). Each directory has a `README.md` index for progressive discovery — read the index first, then drill into the specific file.
+Longer-form documentation lives in [`docs/`](./docs/README.md): **Architecture Decision Records** in [`docs/adr/`](./docs/adr/README.md), **proposals / plans / analyses** in [`docs/proposals-and-projects/`](./docs/proposals-and-projects/README.md), and the **testing guide** in [`docs/testing/`](./docs/testing/README.md). Each directory has a `README.md` index for progressive discovery — read the index first, then drill into the specific file.
 
 **Read `docs/` before** (don't rely on this AGENTS.md alone):
 
 - Designing or implementing a **new feature or subsystem** — check `docs/proposals-and-projects/` for an existing proposal/plan, and `docs/adr/` for decisions that constrain it.
 - Making **architecture, schema, DAO, ORM, deployment, or auth** changes — there is very likely a relevant ADR; read it before changing or contradicting that area.
 - Working on **trades, user settings, search, Docker/deployment, or the routing-controllers→Ts.ED migration** — these all have dedicated docs.
+- **Writing tests** — read [`docs/testing/README.md`](./docs/testing/README.md) for the Prisma/v2 DAO testing patterns (unit vs. integration, available helpers/factories, how to construct the extended Prisma client, minimum coverage per DAO) and the exact run commands.
 - Any task where you're about to make a non-trivial decision that someone may have already made — search `docs/` first.
 
 **When you make a new significant decision or proposal, write it down** in the right place and update that directory's `README.md` index. ADRs are authoritative over proposals when the two disagree. See [`docs/README.md`](./docs/README.md) for the conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,19 @@
 
 This file provides guidance to AI Assistants when working with code in this repository.
 
+## Project Documentation (`docs/`)
+
+Longer-form documentation lives in [`docs/`](./docs/README.md): **Architecture Decision Records** in [`docs/adr/`](./docs/adr/README.md) and **proposals / plans / analyses** in [`docs/proposals-and-projects/`](./docs/proposals-and-projects/README.md). Each directory has a `README.md` index for progressive discovery — read the index first, then drill into the specific file.
+
+**Read `docs/` before** (don't rely on this AGENTS.md alone):
+
+- Designing or implementing a **new feature or subsystem** — check `docs/proposals-and-projects/` for an existing proposal/plan, and `docs/adr/` for decisions that constrain it.
+- Making **architecture, schema, DAO, ORM, deployment, or auth** changes — there is very likely a relevant ADR; read it before changing or contradicting that area.
+- Working on **trades, user settings, search, Docker/deployment, or the routing-controllers→Ts.ED migration** — these all have dedicated docs.
+- Any task where you're about to make a non-trivial decision that someone may have already made — search `docs/` first.
+
+**When you make a new significant decision or proposal, write it down** in the right place and update that directory's `README.md` index. ADRs are authoritative over proposals when the two disagree. See [`docs/README.md`](./docs/README.md) for the conventions.
+
 ## Development Environment Setup
 
 ### Modern Docker Development (Recommended)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Project documentation lives here. This file is the entry point — start here, t
 |---|---|
 | [`adr/`](./adr/README.md) | **Architecture Decision Records** — numbered, dated records of significant technical decisions and the reasoning behind them. Read these before changing or revisiting an area they cover. |
 | [`proposals-and-projects/`](./proposals-and-projects/README.md) | **Proposals, plans, and project write-ups** — design proposals, migration plans, and analyses. More exploratory and longer-lived-draft than ADRs; an ADR is the authoritative record of what was actually decided. |
+| [`testing/`](./testing/README.md) | **Testing guide** — how to write and run tests, focused on the Prisma/v2 DAO patterns: unit vs. integration, shared helpers and factories, constructing the extended Prisma client, minimum coverage per DAO, and run commands. |
 
 ## How these relate
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# TradeMachineServer Documentation
+
+Project documentation lives here. This file is the entry point — start here, then drill into a subdirectory's own `README.md` for its full index.
+
+> **For AI agents / Claude Code:** before starting non-trivial work (new features, schema/DAO changes, architecture decisions, deployment), check whether relevant context already exists here. Read this index, then the subdirectory `README.md`, then the specific file. See "When to read `docs/`" in [`AGENTS.md`](../AGENTS.md).
+
+## Directories
+
+| Directory | What's in it |
+|---|---|
+| [`adr/`](./adr/README.md) | **Architecture Decision Records** — numbered, dated records of significant technical decisions and the reasoning behind them. Read these before changing or revisiting an area they cover. |
+| [`proposals-and-projects/`](./proposals-and-projects/README.md) | **Proposals, plans, and project write-ups** — design proposals, migration plans, and analyses. More exploratory and longer-lived-draft than ADRs; an ADR is the authoritative record of what was actually decided. |
+
+## How these relate
+
+- A **proposal/project doc** explores a problem space and options (may be in-progress, superseded, or partially adopted).
+- An **ADR** records a specific decision that came out of that exploration. When a proposal and an ADR disagree, the ADR wins.
+
+## Adding new docs
+
+- New significant technical decision → add an ADR in [`adr/`](./adr/) (next sequential number) and link it from `adr/README.md`.
+- New design proposal, plan, or analysis → add it to [`proposals-and-projects/`](./proposals-and-projects/) and link it from that directory's `README.md`.
+- Whenever you add a file to a directory here, **update that directory's `README.md` index** so progressive discovery keeps working.

--- a/docs/adr/0002-staff-trade-search-postgres-structured.md
+++ b/docs/adr/0002-staff-trade-search-postgres-structured.md
@@ -1,4 +1,4 @@
-# ADR 0001: Staff trade search — structured Postgres filters
+# ADR 0002: Staff trade search — structured Postgres filters
 
 **Date:** 2026-04-13
 **Status:** Accepted

--- a/docs/adr/0003-trade-builder-v2-daos.md
+++ b/docs/adr/0003-trade-builder-v2-daos.md
@@ -1,0 +1,88 @@
+# ADR 0003: Trade Request builder — v2 DAO scope (first pass)
+
+**Date:** 2026-06-15
+**Status:** Accepted
+**Deciders:** Akosua Asante
+
+## Context
+
+The frontend team is building the new "Trade Request" builder UI on the tRPC v2 stack. They produced several overlapping API wishlists; these were analyzed against the current schema and existing v2 DAOs in [`docs/proposals-and-projects/trade-builder-api-proposal.md`](../proposals-and-projects/trade-builder-api-proposal.md).
+
+Key findings from that analysis:
+
+- The canonical model the frontend wants already exists. Trades are `TradeParticipant` (CREATOR/RECIPIENT) + `TradeItem` line items carrying `senderId`/`recipientId` (fromTeam/toTeam) — not give/get buckets. A "line" maps to an existing `TradeItem` row; `lineId` is its existing `TradeItem.id` UUID (no new field).
+- "Draft" is just `Trade.status = DRAFT`. No separate table; the status enum (`DRAFT → REQUESTED → PENDING → ACCEPTED/REJECTED → SUBMITTED`) covers the lifecycle.
+- The current v2 `TradeDAO` is **read + accept/decline/submit only**. It has no create, no edit, and no line mutations. That is the main gap.
+- Several frontend asks require schema migrations or non-trivial product decisions (roster caps, pick encumbrance, position filtering, commissioner-editable pick-trade date, optimistic concurrency, draft titles).
+
+We operate **single tenant / single league**. There is no `League` model and we are not adding one; no `leagueId` scoping is built into the DAOs.
+
+## Decision
+
+For the June 15, 2026 work we implement **only the unambiguous, zero-migration v2 DAO additions** needed to unblock the builder. Everything requiring a migration or an unresolved product decision is **deferred** (see below). No code is written as part of this ADR — it records the agreed scope.
+
+### In scope (no schema migration)
+
+**`TradeDAO` — builder writes** (each returns the fully hydrated trade via the existing `getTradeById` path):
+
+- `createDraft({ creatorTeamId, participantTeamIds })` — insert `Trade(status=DRAFT)` + participants.
+- `updateDraftParticipants(tradeId, participantTeamIds)` — reconcile the participant set.
+- `addTradeItem(tradeId, { tradeItemType, tradeItemId, senderId, recipientId })` — one line; relies on the existing `@@unique` constraint to dedupe.
+- `updateTradeItem(lineId, { senderId?, recipientId? })` — reroute a line (`lineId` = `TradeItem.id`).
+- `removeTradeItem(lineId)` — remove a line.
+- `deleteDraft(tradeId, requestingUserId)` — **authz:** caller must be an owner of the creator team AND status must be `DRAFT`. Deleting a trade in any other status remains admin-only (existing legacy rule).
+- `listDraftsForUser({ userId / teamIds, status, sort, skip, take })` — thin wrapper over the existing `getTradesByTeam`, scoped to the user's team(s) and `status=DRAFT`.
+- `requestTrade(tradeId, ...)` — the "send" transition: `DRAFT → REQUESTED` write, then enqueue notifications via the existing `ObanDAO`.
+
+**Search / lookup:**
+
+- `TeamDAO.searchTeams({ q, excludeTeamIds })` — team picker. Matches ESPN name (`Team.name`) and CSV name / abbreviation (`team.owners[].csvName`; `abbreviation == csvName`). CSV-weighted ranking done in app code. No missing columns.
+- `PlayerDAO.searchPlayers` enhancement — add an `ownerTeamIds[]` filter (column `Player.leagueTeamId` already exists and is indexed). **No position filtering** (deferred).
+- `DraftPickDAO.searchEligiblePicks({ year, type, round, originalOwnerId, currentOwnerId, skip, take })` — structured, well-indexed pick lookup. The "tradeable right now" date gate **continues to read the existing env var** for this pass; the commissioner-editable Settings-backed date is deferred.
+
+**Validation & review** (one shared `buildTradeSummary(tradeId)` service powering both, so counts are consistent):
+
+- `validateTrade` / `POST .../validate` — **structural + flow only**: exactly one CREATOR, ≥1 recipient, ≥1 line item, per-team `sendsCount`/`receivesCount`, and warnings like `TEAM_RECEIVES_NOTHING`. `canSend = errors.length === 0`.
+- `POST .../review` — canonical per-team `sends`/`receives` projection over the hydrated trade + `notifications.willNotifyVia` + the `validate` result. Pure projection over existing data.
+
+**Notifications:**
+
+- A `willNotifyVia` helper that reads each recipient owner's `userSettings` prefs (`emailEnabled` / `discordDmEnabled` + presence of `discordUserId`). All enqueueing reuses the existing `ObanDAO` — no new notification DAO.
+
+### Explicitly deferred
+
+| Deferred item | Why deferred |
+|---|---|
+| `bulkMutateTradeItems` (lines bulk endpoint) | Nice-to-have, not required for first pass. |
+| Roster-cap validation (`ROSTER_LIMIT_EXCEEDED`) | No roster-size concept in the schema at all; large schema project. Commissioners vet manually. |
+| Pick / asset "encumbered" (already in a pending trade) | Not modeled; would be a raceable cross-table derivation. Commissioners vet manually. |
+| Commissioner-editable pick-trade date in `Settings` | Needs a small migration (`Settings.pickTradeEligibleFrom`). Interim: keep reading the env var. |
+| Position filtering / sorting on asset search | `Player.meta` is plain `json` (not `jsonb`) and position lives there with majors/minors shape mismatch; clean fix is a first-class `position` column + backfill + sync change. Not needed now. |
+| Optimistic concurrency (`Trade.version`, `expectedVersion`, 409) | Drafts are effectively single-editor; low blast radius. `dateModified` can serve as a weak token later. |
+| `Trade.title` (draft titles) | Optional 1-column migration; revisit if product wants named drafts. |
+| `Team.csvName` denormalization | Touches sync/display code; using `owners[0].csvName` is correct for now. |
+| Per-team `eligibleAssetCount` / `lastTradedAt` in list views | Derivable but not stored; fine to defer / compute on demand. |
+| `builderContext` convenience bootstrap procedure | Composable from existing `UserDAO` / `TeamDAO`; optional. |
+| `leagueId` scoping anywhere | Single tenant/league; intentionally not built. |
+
+## Rationale
+
+- **Unblocks the builder with zero migrations.** Every in-scope item maps directly onto existing tables, columns, and indexes, so the frontend can build the full create/edit/search/validate/send loop without waiting on schema work.
+- **Keeps the canonical model.** Building on `TradeParticipant` + `TradeItem(senderId, recipientId)` means the chosen UX (give/get, per-team panels, or ledger) won't force a contract change later.
+- **Defers everything ambiguous.** Roster caps, encumbrance, position search, and the Settings-backed date each need either a migration or a product decision; bundling them now would stall the first pass. Commissioner manual vetting already covers the legality gaps in the interim.
+- **Consistency for free.** Driving `/validate` and `/review` off one `buildTradeSummary` guarantees the send/receive counts match across the builder and the confirm screen — a stated frontend requirement.
+
+## Consequences
+
+- The builder can ship create/edit/search/validate/send entirely on v2 DAOs with no migration.
+- Validation is **structural only** in this pass. Trades that violate roster limits or include encumbered assets can still be sent; commissioners catch these during vetting. The frontend must not present roster-legality guarantees.
+- The pick-eligibility date still requires a redeploy to change (env var) until the deferred `Settings` work lands.
+- No multi-editor safety: concurrent edits to the same draft are last-write-wins. Acceptable given single-editor reality.
+- Follow-up ADR(s) will be needed if/when the deferred migration items (Settings date, position column, `Trade.version`, `Trade.title`) are picked up.
+
+## Revisit triggers
+
+- Product wants roster-aware or encumbrance-aware validation in the builder (not just commissioner vetting).
+- Commissioners need to self-serve the pick-trade date without a redeploy → do the `Settings.pickTradeEligibleFrom` migration.
+- Position filtering/sorting becomes a real builder requirement → promote `position` to a first-class column.
+- Multi-tab / commissioner co-editing of drafts causes lost autosaves → add optimistic concurrency on `Trade`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records (ADRs)
+
+Numbered, dated records of significant technical decisions for TradeMachineServer and the reasoning behind them. Read the relevant ADR before changing or revisiting an area it covers; when an ADR and an older proposal disagree, the ADR is authoritative.
+
+## Index
+
+| # | Title | Date | Status |
+|---|---|---|---|
+| [0001](./0001-user-settings-jsonb-on-user.md) | Store user settings as JSONB on the `user` table | 2026-04-12 | Accepted |
+| [0002](./0002-staff-trade-search-postgres-structured.md) | Staff trade search — structured Postgres filters | 2026-04-13 | Accepted |
+| [0003](./0003-trade-builder-v2-daos.md) | Trade Request builder — v2 DAO scope (first pass) | 2026-06-15 | Accepted |
+
+## Conventions
+
+- **Filename:** `NNNN-kebab-case-title.md`, where `NNNN` is the next sequential zero-padded number. Numbers are unique — do not reuse.
+- **Template** (follow the most recent ADRs, e.g. [0002](./0002-staff-trade-search-postgres-structured.md) / [0003](./0003-trade-builder-v2-daos.md)):
+  - `# ADR NNNN: <title>`
+  - A header block: `**Date:** YYYY-MM-DD`, `**Status:** Proposed | Accepted | Superseded`, `**Deciders:** <names>`
+  - `## Context` → `## Decision` → `## Rationale` (optional) → `## Consequences`
+  - Optional closing sections: `## Revisit triggers` / `## Future work`
+- When adding an ADR, **add a row to the index table above.**

--- a/docs/proposals-and-projects/Potential_Improvements.md
+++ b/docs/proposals-and-projects/Potential_Improvements.md
@@ -1,0 +1,82 @@
+# Potential Improvements
+
+This document outlines potential improvements to the TradeMachine application, prioritized by impact and effort.
+
+## Performance Optimizations
+- **Database Query Optimization** - Add indexes for frequently queried fields in trade and player tables; refine complex queries in `/src/DAO/TradeDAO.ts` (medium effort, high impact)
+- **API Response Caching** - Implement Redis caching for frequently accessed, rarely changing data like player lists; leverage existing Redis infrastructure (low effort, high impact)
+- **Pagination** - Ensure all list endpoints support pagination to reduce payload sizes and improve response times (low effort, high impact)
+- **Background Processing** - Move more intensive operations to background jobs using existing Bull queue infrastructure (medium effort, medium impact)
+- **Batch Database Operations** - Use batch operations for bulk updates/inserts of players and draft picks (medium effort, medium impact)
+
+## Reliability Enhancements
+- **Monitoring** - Add health check endpoints and implement simple dashboard for monitoring system health (low effort, high impact)
+- **Retry Mechanisms** - Enhance retry logic for ESPN API calls and other external integrations in `/src/espn/espnApi.ts` (low effort, medium impact)
+- **Circuit Breakers** - Implement circuit breaker pattern for external dependencies to prevent cascading failures (medium effort, medium impact)
+- **Automated Recovery** - Create self-healing mechanisms for common failure scenarios (high effort, medium impact)
+- **Error Handling** - Standardize error handling across controllers with consistent recovery patterns (medium effort, high impact)
+
+## Technical Debt Reduction
+- **Complete Prisma Migration** - Finish migrating from TypeORM to Prisma, expanding the `/src/DAO/v2/` implementations to replace legacy DAOs (high effort, high impact)
+- **Test Coverage** - Increase unit and integration test coverage focusing on critical trade flows in `/src/api/routes/TradeController.ts` (medium effort, high impact)
+- **API Documentation** - Generate OpenAPI/Swagger documentation from existing controller decorators (low effort, medium impact)
+- **Code Duplication** - Refactor duplicate validation logic in controllers and DAOs (medium effort, medium impact)
+- **Consistent Response Format** - Standardize API response structures across all endpoints (low effort, medium impact)
+
+## Developer Experience
+- **Local Development** - Create Docker Compose setup for easier local development environment (low effort, high impact)
+- **Debugging** - Add structured logging with correlation IDs across service boundaries (low effort, medium impact)
+- **CI/CD Pipeline Enhancement** - Improve existing CI/CD workflows in `.github/workflows/` with caching optimizations and deployment status notifications (low effort, medium impact)
+- **Configuration Management** - Create a centralized config module to replace direct `process.env` access throughout the codebase (medium effort, medium impact)
+- **Database Migration Strategy** - Improve the migration strategy for smoother upgrades as the schema evolves (medium effort, medium impact)
+
+## Security Improvements
+- **Input Validation** - Add consistent validation using class-validator on all API endpoints (medium effort, high impact)
+- **Rate Limiting** - Implement basic rate limiting to prevent abuse (low effort, medium impact)
+- **Dependency Updates** - Update older dependencies like `class-transformer` and `class-validator` (low effort, high impact)
+- **Session Management** - Review and enhance session security configurations in `/src/bootstrap/express.ts` (low effort, medium impact)
+- **Security Headers** - Add appropriate security headers to Express configuration (low effort, medium impact)
+- **CSRF Protection** - Add CSRF protection for sensitive operations (medium effort, high impact)
+
+## User Experience Enhancements
+- **Email Templates** - Improve email templates in `/src/email/templates/` with better mobile support and clearer trade information (low effort, high impact)
+- **Notification Preferences** - Allow users to customize notification preferences between email and Slack (medium effort, medium impact)
+- **Trade Analytics** - Add simple trade analytics to help users evaluate trade fairness (high effort, medium impact)
+- **Trade History** - Enhance trade history views with better filtering and sorting options (low effort, high impact)
+- **In-App Notifications** - Complement email/Slack notifications with an in-app notification system (medium effort, high impact)
+- **WebSocket Integration** - Add WebSockets for real-time trade updates instead of relying on polling (high effort, medium impact)
+
+## API Improvements
+- **API Versioning** - Formalize API versioning strategy, expanding on the existing `/v2/` structure (medium effort, medium impact)
+- **Error Messages** - Improve error messages for common user errors to reduce support requests (low effort, high impact)
+- **Batch Operations** - Add support for batch operations in controllers for commissioners to handle multiple trades/players simultaneously (medium effort, medium impact)
+- **Search Optimization** - Enhance player search functionality with fuzzy matching or advanced filtering (medium effort, high impact)
+- **Permissions Enhancement** - Refine the role-based access control in `/src/authentication/auth.ts` (medium effort, medium impact)
+
+## Database Optimizations
+- **Index Optimization** - Review and optimize database indices, particularly for queries in `/src/DAO/TradeDAO.ts` and `/src/DAO/PlayerDAO.ts` (low effort, high impact)
+- **Query Refactoring** - Refactor complex queries to improve performance (medium effort, medium impact)
+- **Data Archiving** - Implement archiving strategy for historical trade data to maintain performance as data grows (medium effort, medium impact)
+- **Connection Pooling** - Optimize database connection pooling settings (low effort, medium impact)
+- **Schema Optimization** - Review database schema for optimization opportunities, particularly for frequently joined tables (high effort, medium impact)
+
+## Testing Improvements
+- **E2E Testing** - Add end-to-end tests that simulate complete user workflows (high effort, medium impact)
+- **Performance Testing** - Implement performance benchmarks to ensure the system remains responsive as data grows (medium effort, medium impact)
+- **Mocking Strategy** - Improve the mocking strategy in tests to ensure more realistic test scenarios (medium effort, low impact)
+- **Test Data Generation** - Enhance the test factories in `/tests/factories/` to generate more varied test data (low effort, medium impact)
+- **Contract Testing** - Add API contract tests to ensure compatibility with frontend (medium effort, medium impact)
+
+## Low-Hanging Fruit (Quick Wins)
+- **Database Indices** - Add missing indices to improve query performance on trade history and player searches (low effort, high impact)
+- **Cleanup Jobs** - Implement periodic cleanup jobs for expired sessions and old data (low effort, medium impact)
+- **Standardize HTTP Status Codes** - Ensure consistent use of HTTP status codes across all controllers (low effort, medium impact)
+- **Configuration Validation** - Add validation for application configuration at startup (low effort, medium impact)
+- **Error Logging Enhancement** - Improve the error logging in Rollbar to include more context (low effort, medium impact)
+
+## Future Considerations
+- ✅ **Metrics Collection** - Implement basic metrics gathering for monitoring performance and usage patterns (medium effort, medium impact)
+- **External API Integration** - Add integration with additional fantasy baseball data sources beyond ESPN (high effort, high impact)
+- **Trade Suggestion Engine** - Create an AI/algorithm-based trade suggestion feature (high effort, high impact)
+- **Mobile Optimization** - Ensure all features work well on mobile devices (medium effort, high impact)
+- **Bulk Data Import/Export** - Add functionality for commissioners to import/export league data (medium effort, medium impact)

--- a/docs/proposals-and-projects/README.md
+++ b/docs/proposals-and-projects/README.md
@@ -1,0 +1,33 @@
+# Proposals & Projects
+
+Design proposals, migration plans, and analyses for TradeMachineServer. These are more exploratory and longer-lived than [ADRs](../adr/README.md) — some are in-progress, some partially adopted, some historical. When a proposal and an ADR disagree about what was actually decided, **the ADR is authoritative.**
+
+## Index
+
+### Trade features
+| Doc | Summary |
+|---|---|
+| [trade-builder-api-proposal.md](./trade-builder-api-proposal.md) | Backend / v2 DAO proposal for the new Trade Request builder UI — what to add, what existing DAOs cover, and what's deferred. Decided scope is recorded in [ADR 0003](../adr/0003-trade-builder-v2-daos.md). |
+
+### Dockerization & deployment
+| Doc | Summary |
+|---|---|
+| [summary.md](./summary.md) | TradeMachine Server dockerization plan — high-level summary / entry point for the Docker effort. |
+| [docker-deployment-plan.md](./docker-deployment-plan.md) | Docker deployment plan for the server. |
+| [docker-setup-and-deployment-documentation.md](./docker-setup-and-deployment-documentation.md) | Docker setup and deployment documentation. |
+| [postgres_redis_docker_migration.md](./postgres_redis_docker_migration.md) | Plan for migrating PostgreSQL and Redis to Docker. |
+| [server-setup-guide.md](./server-setup-guide.md) | Server setup guide for Docker deployment. |
+| [advanced-github-actions-droplet.md](./advanced-github-actions-droplet.md) | Advanced GitHub Actions deployment to a DigitalOcean droplet. |
+| [health-check-endpoint.ts](./health-check-endpoint.ts) | Reference implementation of a health-check endpoint for Docker health checks (intended for `src/api/routes/`). |
+| [github-actions-workflows/](./github-actions-workflows/) | Sample GitHub Actions workflow YAML (`docker-build-publish.yml`, `docker-deploy.yml`) supporting the Docker deployment plan. |
+
+### Migrations & improvements
+| Doc | Summary |
+|---|---|
+| [ts-ed-migration-plan.md](./ts-ed-migration-plan.md) | Migration plan from `routing-controllers` to Ts.ED for the API framework. |
+| [email-system-analysis.md](./email-system-analysis.md) | Email system analysis & recommendations. |
+| [Potential_Improvements.md](./Potential_Improvements.md) | Grab-bag of potential improvements to the codebase/platform. |
+
+## Adding a doc
+
+Drop the file in this directory and **add a row to the appropriate table above** (create a new section if none fits). If the proposal leads to a firm decision, capture that decision as an [ADR](../adr/README.md) and cross-link the two.

--- a/docs/proposals-and-projects/advanced-github-actions-droplet.md
+++ b/docs/proposals-and-projects/advanced-github-actions-droplet.md
@@ -1,0 +1,369 @@
+# Advanced GitHub Actions Deployment for DigitalOcean Droplet
+
+This document outlines an advanced deployment strategy using GitHub Actions and a single DigitalOcean droplet, offering enterprise-grade features while keeping the infrastructure simple.
+
+## 1. GitHub Actions with Environments & Approvals
+
+```yaml
+name: Deploy
+
+on:
+  push:
+    branches: [main, staging]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tags }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Important for versioning
+
+      # Generate semantic version based on commits
+      - id: version
+        uses: paulhatch/semantic-version@v4
+        with:
+          tag_prefix: "v"
+          major_pattern: "BREAKING CHANGE:"
+          minor_pattern: "feat:"
+          bump_each_commit: false
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
+            type=sha,format=short
+            type=ref,event=branch
+
+      # Build & push with cache
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+
+  deploy-staging:
+    needs: build
+    environment: 
+      name: staging
+      url: https://staging-api.yourdomain.com
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy to staging
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script_stop: true
+          script: |
+            cd /opt/deploy
+            ./deploy.sh staging ${{ needs.build.outputs.image_tag }} ${{ needs.build.outputs.version }}
+
+  deploy-production:
+    needs: [build, deploy-staging]
+    environment: 
+      name: production
+      url: https://api.yourdomain.com
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy to production
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script_stop: true
+          script: |
+            cd /opt/deploy
+            ./deploy.sh production ${{ needs.build.outputs.image_tag }} ${{ needs.build.outputs.version }}
+```
+
+## 2. Traefik as Reverse Proxy on DigitalOcean
+
+```yaml
+# /opt/deploy/docker-compose.yml
+version: '3.8'
+
+services:
+  traefik:
+    image: traefik:v2.9
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
+      - "--certificatesresolvers.myresolver.acme.email=your@email.com"
+      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "letsencrypt:/letsencrypt"
+    restart: unless-stopped
+
+  app_blue:
+    image: ${IMAGE_TAG_BLUE}
+    environment:
+      - "DATABASE_URL=${DATABASE_URL}"
+      # Other environment vars
+    labels:
+      - "traefik.enable=true"
+      # Blue deployment labels
+      - "traefik.http.routers.app-blue.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.app-blue.tls=true"
+      - "traefik.http.routers.app-blue.tls.certresolver=myresolver"
+      - "traefik.http.services.app-blue.loadbalancer.server.port=${APP_PORT}"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${APP_PORT}/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  app_green:
+    image: ${IMAGE_TAG_GREEN}
+    environment:
+      - "DATABASE_URL=${DATABASE_URL}"
+      # Other environment vars
+    labels:
+      - "traefik.enable=true"
+      # Green deployment labels
+      - "traefik.http.routers.app-green.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.app-green.tls=true"
+      - "traefik.http.routers.app-green.tls.certresolver=myresolver"
+      - "traefik.http.services.app-green.loadbalancer.server.port=${APP_PORT}"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${APP_PORT}/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  letsencrypt:
+```
+
+## 3. Deployment Script with Blue-Green Deployments
+
+```bash
+#!/bin/bash
+# /opt/deploy/deploy.sh
+
+set -e
+
+ENVIRONMENT=$1
+IMAGE_TAG=$2
+VERSION=$3
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+
+# Load environment variables
+source /opt/deploy/.env.${ENVIRONMENT}
+
+# Determine which deployment is active and which is idle
+ACTIVE_DEPLOYMENT=$(docker ps --filter "name=app_blue" --format "{{.Names}}" | grep -q "app_blue" && echo "blue" || echo "green")
+IDLE_DEPLOYMENT=$([ "$ACTIVE_DEPLOYMENT" == "blue" ] && echo "green" || echo "blue")
+
+echo "Current active deployment: ${ACTIVE_DEPLOYMENT}"
+echo "Deploying to: ${IDLE_DEPLOYMENT}"
+
+# Backup database before migrations
+pg_dump -U ${DB_USER} -h ${DB_HOST} -d ${DB_NAME} > /opt/backups/pre_deploy_${ENVIRONMENT}_${TIMESTAMP}.sql
+
+# Update the idle deployment
+export IMAGE_TAG_${IDLE_DEPLOYMENT^^}=${IMAGE_TAG}
+docker-compose -f /opt/deploy/docker-compose.yml up -d app_${IDLE_DEPLOYMENT}
+
+# Wait for the idle deployment to be healthy
+echo "Waiting for ${IDLE_DEPLOYMENT} deployment to be healthy..."
+timeout=60
+while [ $timeout -gt 0 ]; do
+  status=$(docker inspect --format='{{.State.Health.Status}}' app_${IDLE_DEPLOYMENT})
+  if [ "$status" == "healthy" ]; then
+    echo "${IDLE_DEPLOYMENT} deployment is healthy!"
+    break
+  fi
+  sleep 5
+  timeout=$((timeout-5))
+  echo "Waiting... ${timeout}s left"
+done
+
+if [ $timeout -le 0 ]; then
+  echo "Deployment failed! ${IDLE_DEPLOYMENT} did not become healthy."
+  exit 1
+fi
+
+# Run database migrations
+docker run --rm --network=host \
+  -e DATABASE_URL=${DATABASE_URL} \
+  ${IMAGE_TAG} npx prisma migrate deploy
+
+# Switch traffic to the new deployment
+sed -i "s/traefik.http.routers.app-${ACTIVE_DEPLOYMENT}.tls=true/traefik.http.routers.app-${ACTIVE_DEPLOYMENT}.tls=false/g" /opt/deploy/docker-compose.yml
+sed -i "s/traefik.http.routers.app-${IDLE_DEPLOYMENT}.tls=false/traefik.http.routers.app-${IDLE_DEPLOYMENT}.tls=true/g" /opt/deploy/docker-compose.yml
+docker-compose -f /opt/deploy/docker-compose.yml up -d traefik
+
+# Log the deployment
+echo "[${TIMESTAMP}] Deployed ${ENVIRONMENT}: ${VERSION} (${IMAGE_TAG})" >> /opt/deploy/deploy_history.log
+
+# Send notification
+curl -X POST ${SLACK_WEBHOOK_URL} \
+  -H "Content-Type: application/json" \
+  -d "{\"text\":\"🚀 Deployed ${ENVIRONMENT} to version ${VERSION}\"}"
+
+echo "Deployment complete!"
+```
+
+## 4. Monitoring Stack
+
+```yaml
+# /opt/monitoring/docker-compose.yml
+version: '3.8'
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.42.0
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+    
+  grafana:
+    image: grafana/grafana:9.4.7
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_SERVER_ROOT_URL=https://grafana.yourdomain.com
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    
+  loki:
+    image: grafana/loki:2.8.0
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    ports:
+      - "3100:3100"
+    restart: unless-stopped
+      
+  promtail:
+    image: grafana/promtail:2.8.0
+    volumes:
+      - ./promtail-config.yaml:/etc/promtail/config.yaml
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/promtail/config.yaml
+    restart: unless-stopped
+    
+volumes:
+  prometheus_data:
+  grafana_data:
+  loki_data:
+```
+
+## 5. Automatic Backups and Rollback
+
+```yaml
+# /opt/backup/docker-compose.yml
+version: '3.8'
+
+services:
+  db-backup:
+    image: postgres:12
+    volumes:
+      - ./backup.sh:/backup.sh
+      - ./restore.sh:/restore.sh
+      - backups:/backups
+    environment:
+      - PGPASSWORD=${DB_PASSWORD}
+      - S3_BUCKET=${S3_BUCKET}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    entrypoint: ["bash", "-c", "chmod +x /backup.sh && /backup.sh"]
+    restart: unless-stopped
+
+volumes:
+  backups:
+```
+
+## Key Features of This Setup
+
+1. **Automatic semantic versioning** based on commit messages
+2. **Blue-green deployments** for zero downtime
+3. **Required approvals** with GitHub Environments
+4. **Automated database backups** before each deployment
+5. **Comprehensive monitoring** with Prometheus, Grafana, and Loki
+6. **SSL termination** with automatic certificate renewal via Traefik
+7. **Deployment history** and notifications
+8. **Automated rollback** capability if health checks fail
+9. **Separate staging environment** with identical configuration
+
+## Implementation Steps
+
+1. **Set up GitHub Environments**:
+   - Go to repository settings → Environments
+   - Create "staging" and "production" environments
+   - Add protection rules and required reviewers for production
+
+2. **Server Setup**:
+   - Create directory structure on DigitalOcean droplet
+   - Set up environment files (`.env.staging` and `.env.production`)
+   - Install Docker and docker-compose
+
+3. **Traefik Setup**:
+   - Configure DNS records for your domains
+   - Set up Traefik as reverse proxy with SSL termination
+
+4. **Deploy the Initial Version**:
+   - Manually deploy the first version to establish the structure
+   - Set up the blue-green deployment pattern
+
+5. **Set Up Monitoring**:
+   - Deploy Prometheus, Grafana, and Loki
+   - Import dashboards for Node.js, PostgreSQL, and system monitoring
+
+6. **Configure Backup System**:
+   - Set up scheduled database backups
+   - Configure S3 or other storage for offsite backups
+   - Test the restore process
+
+7. **Test the Deployment Pipeline**:
+   - Push changes to staging branch
+   - Verify automated deployment
+   - Approve promotion to production
+
+This setup gives you the robustness of a much more complex infrastructure while still using just a single DigitalOcean droplet and GitHub Actions. It's the best of both worlds - enterprise-grade deployment practices with a simple hosting setup.

--- a/docs/proposals-and-projects/docker-deployment-plan.md
+++ b/docs/proposals-and-projects/docker-deployment-plan.md
@@ -1,0 +1,552 @@
+# Docker Deployment Plan for TradeMachine Server
+
+This document outlines a plan to modernize the TradeMachine Server deployment process by containerizing the application with Docker and improving the CI/CD pipeline using GitHub Actions.
+
+## Current State
+
+The TradeMachine Server is a TypeScript/Node.js application with the following key components:
+
+- **Backend Framework**: Express with routing-controllers
+- **Database**: PostgreSQL with dual ORM approach (TypeORM legacy / Prisma new code)
+- **Caching/Job Queue**: Redis with Bull queue for background jobs
+- **Deployment**: PM2 process manager on a Digital Ocean server
+- **CI/CD**: GitHub Actions for building, uploading artifacts, and deploying via SSH
+
+The current deployment workflow:
+1. Builds TypeScript code
+2. Compresses build artifacts
+3. Uploads to Digital Ocean server via SCP
+4. Extracts files and restarts PM2 process
+
+## Dockerization Plan
+
+### 1. Docker Image Design
+
+#### Dockerfile Structure
+
+```dockerfile
+# Base image, in this first stage, we transpile TypeScript to JavaScript
+FROM node:16-slim as build
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files and install dependencies (leverage Docker layer caching)
+COPY package*.json ./
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build TypeScript code
+RUN make build
+
+# Create production image
+FROM node:16-slim as production
+
+# Create app directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install production dependencies only
+RUN npm ci --only=production
+
+# Copy built application
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/ormconfig.js ./
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/src/email/templates ./dist/email/templates
+
+# Generate Prisma client
+RUN npx prisma generate
+
+# Create non-root user for security
+RUN groupadd -r app && useradd -r -g app app
+RUN chown -R app:app /app
+USER app
+
+# Environment variables
+ENV NODE_ENV=production
+ENV PORT=3000
+
+# Expose port
+EXPOSE 3000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:3000/api/health || exit 1
+
+# Run command
+CMD ["node", "-r", "dotenv/config", "./dist/server.js"]
+```
+
+### 2. Docker Compose for Local Development
+
+```yaml
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      target: build
+    ports:
+      - "3001:3001"
+    environment:
+      - NODE_ENV=development
+      - PORT=3001
+      - IP=0.0.0.0
+      - PG_USER=postgres
+      - PG_PASSWORD=postgres
+      - PG_DB=trade_machine
+      - ORM_CONFIG=development
+      - BASE_DIR=/app
+      - REDIS_IP=redis
+      - SESSION_SECRET=local_dev_secret
+      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/trade_machine?schema=dev
+    volumes:
+      - ./:/app
+      - /app/node_modules
+    depends_on:
+      - postgres
+      - redis
+    command: make dev-server
+
+  postgres:
+    image: postgres:12
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=trade_machine
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:5
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  postgres_data:
+  redis_data:
+```
+
+### 3. Production Container Configuration
+
+For production, we'll need to consider:
+
+1. **Secrets Management**: Using environment variables injected at runtime
+2. **Persistent Storage**: For logs and any other data that needs to persist
+3. **Network Isolation**: Proper network security for database and Redis connections
+4. **Resource Limits**: Setting memory and CPU limits for containers
+5. **Health Checks**: For container orchestration and monitoring
+
+## GitHub Actions CI/CD Pipeline
+
+### 1. Building and Publishing Docker Image
+
+```yaml
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [main, staging]
+  pull_request:
+    branches: [main, staging]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Notify Rollbar of deploy start
+        uses: rollbar/github-deploy-action@2.1.2
+        id: rollbar_pre_deploy
+        with:
+          environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+          version: ${{ github.sha }}
+          status: "started"
+          local_username: ${{ github.actor }}
+        env:
+          ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+          ROLLBAR_USERNAME: "aaasante"
+
+      - uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Notify Rollbar of build completion
+        if: github.event_name != 'pull_request'
+        uses: rollbar/github-deploy-action@2.1.2
+        with:
+          environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+          version: ${{ github.sha }}
+          status: "succeeded"
+          local_username: ${{ github.actor }}
+        env:
+          ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+          ROLLBAR_USERNAME: "aaasante"
+          DEPLOY_ID: ${{ steps.rollbar_pre_deploy.outputs.deploy_id }}
+```
+
+### 2. Deployment Workflow
+
+```yaml
+name: Deploy Docker Image
+
+on:
+  workflow_run:
+    workflows: ["Build and Publish Docker Image"]
+    branches: [main, staging]
+    types: [completed]
+  # Manual trigger for feature branches
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+        - staging
+        - production
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    strategy:
+      matrix:
+        include:
+          # Staging deployment conditions
+          - environment: staging
+            condition: ${{ 
+              (github.event.workflow_run.head_branch == 'staging') ||
+              (github.event.workflow_run.head_branch == 'main') ||
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
+            }}
+            app_dir: /opt/Apps/StagingTradeMachine
+            image_tag: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+            port: 3001
+          
+          # Production deployment conditions  
+          - environment: production
+            condition: ${{ 
+              (github.event.workflow_run.head_branch == 'main') ||
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
+            }}
+            app_dir: /opt/Apps/TradeMachine
+            image_tag: main
+            port: 3000
+
+    steps:
+      - name: Skip if condition not met
+        if: ${{ !matrix.condition }}
+        run: echo "Skipping ${{ matrix.environment }} deployment" && exit 0
+
+      - name: Run database migrations for ${{ matrix.environment }}
+        if: ${{ matrix.condition }}
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd ${{ matrix.app_dir }}
+            source .env
+            docker pull ghcr.io/${{ github.repository }}:${{ matrix.image_tag }}
+            docker run --rm --env-file .env ghcr.io/${{ github.repository }}:${{ matrix.image_tag }} npx prisma migrate deploy
+
+      - name: Deploy ${{ matrix.environment }}
+        if: ${{ matrix.condition }}
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd ${{ matrix.app_dir }}
+            
+            # Update IMAGE_TAG in .env
+            sed -i 's/^IMAGE_TAG=.*/IMAGE_TAG=${{ matrix.image_tag }}/' .env
+            
+            # Login to registry
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            
+            # Deploy
+            docker-compose pull app
+            docker-compose up -d app
+            
+            # Health check
+            timeout=60
+            while [ $timeout -gt 0 ]; do
+              if curl -f http://localhost:${{ matrix.port }}/api/health; then
+                echo "${{ matrix.environment }} deployment successful"
+                exit 0
+              fi
+              sleep 5
+              timeout=$((timeout-5))
+            done
+            
+            echo "${{ matrix.environment }} health check failed"
+            docker-compose logs app
+            exit 1
+
+      - name: Notify Rollbar of deployment
+        if: ${{ matrix.condition }}
+        uses: rollbar/github-deploy-action@2.1.2
+        with:
+          environment: ${{ matrix.environment }}
+          version: ${{ github.sha }}
+          status: "succeeded"
+          local_username: ${{ github.actor }}
+        env:
+          ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+          ROLLBAR_USERNAME: "aaasante"
+```
+
+## Deployment Strategy
+
+### 1. Initial Setup
+
+The deployment strategy uses static docker-compose files on the server with environment variables for dynamic configuration, avoiding the need to transfer compose files on every deployment.
+
+#### Server Directory Structure
+```
+/opt/Apps/
+├── TradeMachine/           # Production
+│   ├── docker-compose.yml
+│   └── .env
+└── StagingTradeMachine/    # Staging  
+    ├── docker-compose.yml
+    └── .env
+```
+
+#### Static docker-compose.yml Files
+
+**Staging** (`/opt/Apps/StagingTradeMachine/docker-compose.yml`):
+```yaml
+version: '3.8'
+
+services:
+  app:
+    image: ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG}
+    container_name: staging_trademachine
+    restart: always
+    env_file: .env
+    ports:
+      - "3001:3000"  # Staging on port 3001
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+```
+
+**Production** (`/opt/Apps/TradeMachine/docker-compose.yml`):
+```yaml
+version: '3.8'
+
+services:
+  app:
+    image: ghcr.io/${GITHUB_REPOSITORY}:${IMAGE_TAG}
+    container_name: prod_trademachine
+    restart: always
+    env_file: .env
+    ports:
+      - "3000:3000"  # Production on port 3000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+```
+
+#### Environment Files
+
+Each directory has its own `.env` file with environment-specific configurations:
+
+**Staging `.env`:**
+```
+IMAGE_TAG=staging
+DATABASE_URL=postgresql://...staging_db
+ENVIRONMENT=staging
+NODE_ENV=production
+PORT=3000
+IP=0.0.0.0
+ORM_CONFIG=staging
+BASE_DIR=/app
+REDIS_IP=...
+REDIS_PORT=...
+REDISPASS=...
+SESSION_SECRET=...
+ROLLBAR_ACCESS_TOKEN=...
+ROLLBAR_ENVIRONMENT=staging
+APP_ENV=staging
+```
+
+**Production `.env`:**
+```
+IMAGE_TAG=main
+DATABASE_URL=postgresql://...prod_db
+ENVIRONMENT=production
+NODE_ENV=production
+PORT=3000
+IP=0.0.0.0
+ORM_CONFIG=production
+BASE_DIR=/app
+REDIS_IP=...
+REDIS_PORT=...
+REDISPASS=...
+SESSION_SECRET=...
+ROLLBAR_ACCESS_TOKEN=...
+ROLLBAR_ENVIRONMENT=production
+APP_ENV=production
+```
+
+### 2. Deployment Logic
+
+The deployment workflow now supports:
+
+| Trigger | Staging Deploy | Production Deploy |
+|---------|---------------|-------------------|
+| Push to `staging` | ✅ | ❌ |
+| Push to `main` | ✅ | ✅ |
+| Manual trigger | ✅ (if selected) | ✅ (if selected) |
+| Feature branch | ❌ (unless manual) | ❌ |
+
+#### Manual Deployment for Feature Branches
+
+For deploying feature branches to staging:
+1. Go to GitHub Actions → "Deploy Docker Image" workflow
+2. Click "Run workflow" 
+3. Select "staging" environment
+4. The workflow will build and deploy your current branch's image
+
+#### Alternative: Comment-based Deployment
+
+Optionally, you can add PR comment triggers:
+
+```yaml
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  deploy-staging:
+    if: contains(github.event.comment.body, '/deploy staging')
+    # ... deploy logic using manual workflow_dispatch
+```
+
+Then comment `/deploy staging` on any PR to trigger a staging deployment.
+
+### 3. Deployment Process
+
+1. **Image Tag Update**: The workflow updates the `IMAGE_TAG` in the server's `.env` file
+2. **Docker Pull**: Pulls the latest image for the specified tag
+3. **Container Restart**: Uses `docker-compose up -d` to restart with the new image
+4. **Health Check**: Verifies the application is responding on the correct port
+5. **Database Migrations**: Runs automatically before deployment using a temporary container
+
+### 2. Container Orchestration
+
+While a single Docker container with docker-compose is sufficient initially, consider a more robust orchestration for the future:
+
+- **Docker Swarm**: Simple cluster management built into Docker
+- **Kubernetes**: For more complex scaling and management needs
+
+### 3. High Availability Considerations
+
+1. **Health Checks**: Configured in the container to enable automatic restarts
+2. **Monitoring**: Set up container monitoring with Prometheus/Grafana
+3. **Logging**: Configure centralized logging with ELK stack or similar
+4. **Backup Strategy**: Regular database backups and container configuration backups
+
+### 4. Scaling Strategy
+
+1. **Horizontal Scaling**: Run multiple application containers behind a load balancer
+2. **Database Scaling**: Consider read replicas for PostgreSQL
+3. **Redis Cluster**: For scaling the job queue and session store
+
+## Migration Plan
+
+### Phase 1: Local Development Setup
+
+1. Create the Dockerfile and docker-compose.yml
+2. Test building and running the application locally
+3. Update documentation for local development
+
+### Phase 2: CI/CD Pipeline Setup
+
+1. Create the GitHub Actions workflow for building and publishing the Docker image
+2. Test the CI/CD pipeline with a feature branch
+3. Verify the Docker image is correctly published to GitHub Container Registry
+
+### Phase 3: Server Setup
+
+1. Install Docker and docker-compose on the production server
+2. Create the .env file with production secrets
+3. Set up container monitoring and logging
+4. Configure firewall and networking
+
+### Phase 4: Production Deployment
+
+1. Test the deployment workflow with the staging environment
+2. Deploy to production using the new Docker-based workflow
+3. Verify application functionality and performance
+4. Switch DNS to the new Docker-based application
+
+### Phase 5: Cleanup and Documentation
+
+1. Remove the old deployment scripts and configurations
+2. Update documentation for the new deployment process
+3. Train team members on the new workflow
+
+## Conclusion
+
+Dockerizing the TradeMachine Server will provide several benefits:
+
+1. **Consistent Environments**: Development, staging, and production will use the same container configuration
+2. **Simplified Deployment**: Automated, reliable deployments with rollback capability
+3. **Scalability**: Easier to scale horizontally as needed
+4. **Portability**: Can be run on any infrastructure that supports Docker
+5. **Security**: Improved isolation between application components
+
+This plan outlines a gradual migration to a Docker-based workflow without disrupting the existing application.

--- a/docs/proposals-and-projects/docker-setup-and-deployment-documentation.md
+++ b/docs/proposals-and-projects/docker-setup-and-deployment-documentation.md
@@ -1,0 +1,414 @@
+# Docker Setup and Deployment Documentation
+
+This document provides instructions for setting up, developing, and deploying the TradeMachine Server application using Docker.
+
+## Table of Contents
+
+1. [Local Development Setup](#local-development-setup)
+2. [Understanding the Dockerfile](#understanding-the-dockerfile)
+3. [Docker-Compose Configuration](#docker-compose-configuration)
+4. [Deployment Process](#deployment-process)
+5. [Environment Variables](#environment-variables)
+6. [Troubleshooting](#troubleshooting)
+7. [Advanced Usage](#advanced-usage)
+
+## Local Development Setup
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed
+- Git repository cloned locally
+
+### Starting the Development Environment
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/akosasante/TradeMachineServer.git
+   cd TradeMachineServer
+   ```
+
+2. Start the development environment:
+   ```bash
+   docker-compose up -d
+   ```
+
+3. View logs:
+   ```bash
+   docker-compose logs -f app
+   ```
+
+4. Access the application:
+   - API Server: http://localhost:3000
+   - You can now make changes to the code and the server will automatically reload
+
+### Running Tests
+
+To run tests inside the Docker container:
+
+```bash
+docker-compose exec app npm run test
+```
+
+To run specific tests:
+
+```bash
+docker-compose exec app npm run test-unit
+docker-compose exec app npm run test-integration
+```
+
+### Stopping the Development Environment
+
+```bash
+docker-compose down
+```
+
+To completely remove volumes (including database data):
+
+```bash
+docker-compose down -v
+```
+
+## Understanding the Dockerfile
+
+The Dockerfile uses a multi-stage build process to optimize the final image size and security:
+
+### Build Stage
+
+```dockerfile
+FROM node:16-slim as build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN make build
+```
+
+This stage:
+- Uses Node.js 16 as the base image
+- Installs all dependencies
+- Builds the TypeScript code
+
+### Production Stage
+
+```dockerfile
+FROM node:16-slim as production
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --only=production
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/ormconfig.js ./
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/src/email/templates ./dist/email/templates
+
+RUN npx prisma generate
+
+RUN groupadd -r app && useradd -r -g app app
+RUN chown -R app:app /app
+USER app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV IP=0.0.0.0
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:3000/api/health || exit 1
+
+CMD ["node", "-r", "dotenv/config", "./dist/server.js"]
+```
+
+This stage:
+- Uses the same Node.js base image
+- Installs only production dependencies
+- Copies built files from the build stage
+- Generates Prisma client
+- Creates and switches to a non-root user for security
+- Sets environment variables
+- Exposes port 3000
+- Adds a health check
+- Defines the start command
+
+## Docker-Compose Configuration
+
+The `docker-compose.yml` file sets up three services:
+
+### App Service
+
+```yaml
+app:
+  build:
+    context: .
+    target: build
+  ports:
+    - "3000:3000"
+  environment:
+    - NODE_ENV=development
+    - PORT=3000
+    - IP=0.0.0.0
+    - PG_USER=postgres
+    - PG_PASSWORD=postgres
+    - PG_DB=trade_machine
+    - ORM_CONFIG=development
+    - BASE_DIR=/app
+    - REDIS_IP=redis
+    - REDIS_PORT=6379
+    - SESSION_SECRET=local_dev_secret
+    - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/trade_machine?schema=dev
+    - ENABLE_LOGS=true
+  volumes:
+    - ./:/app
+    - /app/node_modules
+  depends_on:
+    - postgres
+    - redis
+  command: npm run dev-server
+```
+
+This service:
+- Builds from the Dockerfile using the build target
+- Maps port 3000 to the host
+- Sets development environment variables
+- Mounts the current directory to /app in the container
+- Preserves node_modules using volume mounting
+- Depends on PostgreSQL and Redis services
+- Runs the development server command
+
+### PostgreSQL Service
+
+```yaml
+postgres:
+  image: postgres:14
+  environment:
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=postgres
+    - POSTGRES_DB=trade_machine
+  ports:
+    - "5432:5432"
+  volumes:
+    - postgres_data:/var/lib/postgresql/data
+  healthcheck:
+    test: ["CMD-SHELL", "pg_isready -U postgres"]
+    interval: 10s
+    timeout: 5s
+    retries: 5
+```
+
+This service:
+- Uses PostgreSQL 14
+- Sets up database credentials
+- Maps port 5432 to the host
+- Uses a named volume for persistent data
+- Includes a health check
+
+### Redis Service
+
+```yaml
+redis:
+  image: redis:6
+  ports:
+    - "6379:6379"
+  volumes:
+    - redis_data:/data
+  healthcheck:
+    test: ["CMD", "redis-cli", "ping"]
+    interval: 10s
+    timeout: 5s
+    retries: 5
+```
+
+This service:
+- Uses Redis 6
+- Maps port 6379 to the host
+- Uses a named volume for persistent data
+- Includes a health check
+
+## Deployment Process
+
+The deployment process is automated through GitHub Actions. Here's how it works:
+
+### 1. Build and Publish Workflow
+
+When code is pushed to the `main` or `staging` branches, the first workflow:
+
+- Builds the Docker image
+- Pushes it to GitHub Container Registry
+- Tags it with the branch name, commit SHA, and 'latest'
+
+### 2. Deploy Workflow
+
+After the build workflow completes successfully:
+
+- Determines the environment (production or staging) based on the branch
+- Creates a `docker-compose.yml` file for the appropriate environment
+- Transfers it to the server
+- Runs database migrations
+- Deploys and starts the container
+- Verifies container health
+
+### Manual Deployment
+
+If needed, you can manually deploy the application:
+
+1. Log in to the server:
+   ```bash
+   ssh user@server
+   ```
+
+2. Navigate to the application directory:
+   ```bash
+   cd /opt/Apps/TradeMachine  # For production
+   # or
+   cd /opt/Apps/StagingTradeMachine  # For staging
+   ```
+
+3. Pull the latest image:
+   ```bash
+   docker pull ghcr.io/akosasante/trademachineserver:main  # For production
+   # or
+   docker pull ghcr.io/akosasante/trademachineserver:staging  # For staging
+   ```
+
+4. Restart the container:
+   ```bash
+   docker-compose down
+   docker-compose up -d
+   ```
+
+## Environment Variables
+
+The application requires several environment variables to function properly:
+
+### Required Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `NODE_ENV` | Environment mode | `production`, `development`, `test` |
+| `PORT` | Server port | `3000` |
+| `IP` | Server IP address | `0.0.0.0` |
+| `ORM_CONFIG` | ORM configuration name | `production`, `staging`, `development` |
+| `BASE_DIR` | Base directory | `/app` |
+| `DATABASE_URL` | Prisma database URL | `postgresql://user:pass@host:port/db?schema=public` |
+| `REDIS_IP` | Redis host | `redis` or IP address |
+| `REDIS_PORT` | Redis port | `6379` |
+| `SESSION_SECRET` | Session encryption key | Random string |
+
+### Optional Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `REDISPASS` | Redis password | None |
+| `PG_USER` | PostgreSQL username | From DATABASE_URL |
+| `PG_PASSWORD` | PostgreSQL password | From DATABASE_URL |
+| `PG_DB` | PostgreSQL database name | From DATABASE_URL |
+| `ROLLBAR_ACCESS_TOKEN` | Rollbar token | None |
+| `ROLLBAR_ENVIRONMENT` | Rollbar environment | NODE_ENV |
+| `ENABLE_LOGS` | Enable console logging | `true` in development |
+| `DB_LOGS` | Enable database query logging | `false` |
+
+## Troubleshooting
+
+### Common Issues
+
+#### Container Not Starting
+
+Check the logs:
+
+```bash
+docker-compose logs app
+```
+
+Verify environment variables:
+
+```bash
+docker-compose config
+```
+
+#### Database Connection Issues
+
+Verify the database is running:
+
+```bash
+docker-compose ps postgres
+```
+
+Check the connection inside the container:
+
+```bash
+docker-compose exec app npx prisma db pull
+```
+
+#### Redis Connection Issues
+
+Verify Redis is running:
+
+```bash
+docker-compose ps redis
+```
+
+Test the connection:
+
+```bash
+docker-compose exec redis redis-cli ping
+```
+
+#### Container Health Check Failing
+
+Check the health status:
+
+```bash
+docker inspect --format='{{json .State.Health}}' $(docker-compose ps -q app) | jq
+```
+
+### Debugging
+
+To start the container in debug mode:
+
+```bash
+docker-compose run --service-ports app npm run debug-server
+```
+
+## Advanced Usage
+
+### Custom Database Migrations
+
+To run custom database migrations:
+
+```bash
+docker-compose exec app npx prisma migrate dev --name my_migration
+```
+
+### Accessing the Database Directly
+
+```bash
+docker-compose exec postgres psql -U postgres -d trade_machine
+```
+
+### Viewing Redis Data
+
+```bash
+docker-compose exec redis redis-cli
+```
+
+Then:
+
+```
+AUTH your_redis_password  # If configured
+KEYS *
+```
+
+### Scaling in Production
+
+For production environments, consider:
+
+1. Using Docker Swarm or Kubernetes for orchestration
+2. Setting up database replication for high availability
+3. Configuring Redis Sentinel or Redis Cluster
+4. Implementing a proper logging stack (ELK or similar)
+5. Setting up comprehensive monitoring with Prometheus and Grafana

--- a/docs/proposals-and-projects/email-system-analysis.md
+++ b/docs/proposals-and-projects/email-system-analysis.md
@@ -1,0 +1,192 @@
+# Email System Analysis & Recommendations
+
+## Current Architecture Analysis
+
+**Password Reset Flow:**
+1. `AuthController.sendResetEmail` → validates user & generates token
+2. `UserDAO.setPasswordExpires` → sets 1-hour expiration + UUID token
+3. `EmailPublisher.queueResetEmail` → queues job with Bull/Redis
+4. `EmailConsumer` → processes job via `handleEmailJob`
+5. `EMAILER.sendPasswordResetEmail` → sends via SendinBlue SMTP
+
+### Key Components
+- **Publishers** (`src/email/publishers.ts`): Queue email jobs using Bull
+- **Consumers** (`src/email/consumers.ts`): Process queued jobs
+- **Processors** (`src/email/processors.ts`): Job handler logic
+- **Mailer** (`src/email/mailer.ts`): SendinBlue integration and templates
+- **Templates** (`src/email/templates/`): Pug templates for email content
+
+## Pros of Current Approach
+
+✅ **Reliable Queue System**: Bull + Redis provides durability and retry logic
+✅ **Separation of Concerns**: Clear publisher/consumer pattern
+✅ **Retry Logic**: Exponential backoff (3 attempts, 30s base delay)
+✅ **Environment Awareness**: Different queues for test/staging/prod
+✅ **Comprehensive Logging**: Good visibility into job lifecycle
+✅ **Template System**: Clean email template management with Pug
+✅ **Security**: 1-hour token expiration, secure token generation
+
+## Cons of Current Approach
+
+❌ **Complex Architecture**: 6+ files involved for simple email sending
+❌ **Data Serialization**: JSON stringify/parse for entities creates coupling
+❌ **Tight Coupling**: Email logic mixed with ORM models
+❌ **Mixed ORMs**: TypeORM entities in Prisma migration context
+❌ **Error Swallowing**: Password reset errors return `undefined` instead of failing
+❌ **Hard-coded Email**: SendinBlue SMTP credentials in code
+❌ **Template Coupling**: Email templates tightly coupled to ORM models
+❌ **Limited Observability**: No email delivery tracking beyond SendinBlue webhooks
+
+## Alternative Approaches
+
+### 1. Simplified Direct Approach
+```typescript
+// Single service class
+class EmailService {
+  async sendPasswordReset(userId: string, email: string) {
+    const token = await this.userService.generateResetToken(userId);
+    return this.transporter.sendMail({...});
+  }
+}
+```
+**Pros**: Simpler, fewer moving parts, easier debugging
+**Cons**: Less resilient, no retry logic, blocks request threads
+
+### 2. Event-Driven Architecture
+```typescript
+// Domain events
+eventBus.emit('user.passwordResetRequested', { userId, email });
+
+// Handler
+@EventHandler('user.passwordResetRequested')
+async handlePasswordReset(event) { /* send email */ }
+```
+**Pros**: Loose coupling, extensible, better domain modeling
+**Cons**: More complex, eventual consistency challenges
+
+### 3. Modern Queue Solutions
+- **Agenda.js**: MongoDB-based, simpler than Bull
+- **Bee-Queue**: Faster, simpler Redis queues
+- **AWS SQS/SNS**: Managed, no Redis infrastructure
+- **Temporal**: Workflow orchestration, better observability
+
+## Elixir App Integration Considerations
+
+### Advantages of Offloading to Elixir:
+- ✅ Better concurrency model (Actor system)
+- ✅ Built-in fault tolerance (supervision trees)
+- ✅ Superior job scheduling (GenServer + :timer)
+- ✅ Lower resource usage for I/O-bound tasks
+- ✅ Consolidates background job logic
+
+### Migration Strategy:
+1. **Phase 1**: Move scheduled jobs (ESPN updates, etc.)
+2. **Phase 2**: Move transactional emails
+3. **Phase 3**: Deprecate Node.js email infrastructure
+
+### API Integration Options:
+```elixir
+# HTTP endpoint approach
+POST /api/emails/password-reset
+{"user_id": "123", "email": "user@example.com"}
+
+# Message queue approach
+Phoenix.PubSub.broadcast("email_jobs", "password_reset", %{user_id: 123})
+```
+
+## Recommendations
+
+### Short Term (Current Migration Context)
+
+#### 1. Simplify Current System
+```typescript
+// Eliminate JSON serialization, pass IDs only
+interface EmailJob {
+  userId: string;
+  type: 'password_reset' | 'registration';
+  metadata?: Record<string, any>;
+}
+```
+
+#### 2. Improve Error Handling
+```typescript
+// Don't swallow errors - let them bubble up for retry
+.catch((err: Error) => {
+  logger.error('Password reset failed', err);
+  throw err; // Let Bull retry
+});
+```
+
+#### 3. Decouple from ORM Models
+```typescript
+// Use DTOs instead of full entities
+interface PasswordResetData {
+  email: string;
+  displayName: string;
+  resetToken: string;
+}
+```
+
+### Medium Term
+
+#### 4. Migrate to Elixir App
+- Start with password reset emails as proof-of-concept
+- Use HTTP API between Node.js and Elixir initially
+- Gradually move all email functionality
+
+#### 5. Improve Observability
+```typescript
+// Add email delivery metrics
+emailSentCounter.inc({ type: 'password_reset', status: 'success' });
+emailDeliveryTime.observe(duration);
+```
+
+### Long Term
+
+#### 6. Full Event-Driven Architecture
+```typescript
+// Domain events
+await eventBus.emit('user.passwordResetRequested', {
+  userId: user.id,
+  requestedAt: new Date(),
+  ipAddress: request.ip
+});
+```
+
+#### 7. Modern Email Service
+- Consider Resend, Postmark, or AWS SES
+- Better deliverability and analytics
+- Built-in template management
+
+## Immediate Action Plan
+
+Given your migration context, I recommend:
+
+1. **Keep current system** for now - it works reliably
+2. **Start Elixir integration** with password reset emails as POC
+3. **Gradually migrate** email functionality to Elixir
+4. **Simplify Node.js side** to just trigger jobs via HTTP/message queue
+
+This approach leverages your existing Elixir investment while maintaining current reliability during the TypeORM → Prisma migration.
+
+## Technical Debt Items
+
+### High Priority
+- [ ] Remove JSON serialization of full entities
+- [ ] Improve error handling (don't swallow errors)
+- [ ] Move hardcoded credentials to environment variables
+
+### Medium Priority
+- [ ] Decouple email templates from ORM models
+- [ ] Add email delivery metrics and monitoring
+- [ ] Implement proper email delivery tracking
+
+### Low Priority
+- [ ] Consider migrating from Bull to simpler queue solution
+- [ ] Evaluate modern email service providers
+- [ ] Implement event-driven architecture for emails
+
+---
+
+**Analysis Date**: January 2025
+**Context**: During TypeORM → Prisma migration

--- a/docs/proposals-and-projects/github-actions-workflows/docker-build-publish.yml
+++ b/docs/proposals-and-projects/github-actions-workflows/docker-build-publish.yml
@@ -1,0 +1,72 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [main, staging]
+  pull_request:
+    branches: [main, staging]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Notify Rollbar of deploy start
+        if: github.event_name != 'pull_request'
+        uses: rollbar/github-deploy-action@2.1.2
+        id: rollbar_pre_deploy
+        with:
+          environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+          version: ${{ github.sha }}
+          status: "started"
+          local_username: ${{ github.actor }}
+        env:
+          ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+          ROLLBAR_USERNAME: "aaasante"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Notify Rollbar of build completion
+        if: github.event_name != 'pull_request'
+        uses: rollbar/github-deploy-action@2.1.2
+        with:
+          environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+          version: ${{ github.sha }}
+          status: "succeeded"
+          local_username: ${{ github.actor }}
+        env:
+          ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+          ROLLBAR_USERNAME: "aaasante"
+          DEPLOY_ID: ${{ steps.rollbar_pre_deploy.outputs.deploy_id }}

--- a/docs/proposals-and-projects/github-actions-workflows/docker-deploy.yml
+++ b/docs/proposals-and-projects/github-actions-workflows/docker-deploy.yml
@@ -1,0 +1,155 @@
+name: Deploy Docker Image
+
+on:
+  workflow_run:
+    workflows: ["Build and Publish Docker Image"]
+    branches: [main, staging]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Get branch name
+        uses: dawidd6/action-get-workflow-origin@v1
+        id: workflow-origin
+        with:
+          workflow_run: ${{ github.event.workflow_run.id }}
+
+      - name: Set environment variables
+        id: env-vars
+        run: |
+          if [[ "${{ steps.workflow-origin.outputs.branch }}" == "main" ]]; then
+            echo "ENVIRONMENT=production" >> $GITHUB_ENV
+            echo "APP_DIR=/opt/Apps/TradeMachine" >> $GITHUB_ENV
+            echo "SERVICE_NAME=trademachine" >> $GITHUB_ENV
+            echo "SCHEMA=public" >> $GITHUB_ENV
+            echo "PORT=3005" >> $GITHUB_ENV
+            echo "DB_URL=${{ secrets.PROD_DATABASE_URL }}" >> $GITHUB_ENV
+          else
+            echo "ENVIRONMENT=staging" >> $GITHUB_ENV
+            echo "APP_DIR=/opt/Apps/StagingTradeMachine" >> $GITHUB_ENV
+            echo "SERVICE_NAME=staging_trademachine" >> $GITHUB_ENV
+            echo "SCHEMA=staging" >> $GITHUB_ENV
+            echo "PORT=3015" >> $GITHUB_ENV
+            echo "DB_URL=${{ secrets.STAGING_DATABASE_URL }}" >> $GITHUB_ENV
+          fi
+
+      - name: Create docker-compose.yml file
+        run: |
+          cat > docker-compose.yml << 'EOF'
+          version: '3.8'
+          
+          services:
+            app:
+              image: ghcr.io/${{ github.repository }}:${{ steps.workflow-origin.outputs.branch }}
+              restart: always
+              environment:
+                - NODE_ENV=production
+                - PORT=${{ env.PORT }}
+                - IP=0.0.0.0
+                - ORM_CONFIG=${{ env.ENVIRONMENT }}
+                - BASE_DIR=/app
+                - DATABASE_URL=${DATABASE_URL}
+                - REDIS_IP=${REDIS_IP}
+                - REDIS_PORT=${REDIS_PORT}
+                - REDISPASS=${REDISPASS}
+                - SESSION_SECRET=${SESSION_SECRET}
+                - ROLLBAR_ACCESS_TOKEN=${ROLLBAR_ACCESS_TOKEN}
+                - ROLLBAR_ENVIRONMENT=${ENVIRONMENT}
+                - APP_ENV=${ENVIRONMENT}
+              ports:
+                - "${{ env.PORT }}:${{ env.PORT }}"
+              healthcheck:
+                test: ["CMD", "curl", "-f", "http://localhost:${{ env.PORT }}/api/health"]
+                interval: 30s
+                timeout: 10s
+                retries: 3
+                start_period: 20s
+              networks:
+                - app-network
+          
+          networks:
+            app-network:
+              driver: bridge
+          EOF
+
+      - name: Transfer docker-compose file to server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.SSH_PORT }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "docker-compose.yml"
+          target: ${{ env.APP_DIR }}
+
+      - name: Run database migrations
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.SSH_PORT }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd ${{ env.APP_DIR }}
+            export DATABASE_URL='${{ env.DB_URL }}'
+            docker pull ghcr.io/${{ github.repository }}:${{ steps.workflow-origin.outputs.branch }}
+            docker run --rm -e DATABASE_URL='${{ env.DB_URL }}' ghcr.io/${{ github.repository }}:${{ steps.workflow-origin.outputs.branch }} npx prisma migrate deploy
+
+      - name: Deploy and start container
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.SSH_PORT }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd ${{ env.APP_DIR }}
+            
+            # Load environment variables
+            source .env
+            
+            # Login to GitHub Container Registry
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            
+            # Pull latest image
+            docker pull ghcr.io/${{ github.repository }}:${{ steps.workflow-origin.outputs.branch }}
+            
+            # Stop old container (if running)
+            docker-compose down --remove-orphans
+            
+            # Start new container
+            docker-compose up -d
+            
+            # Check if container is running and healthy
+            timeout=60
+            while [ $timeout -gt 0 ]; do
+              status=$(docker-compose ps -q app | xargs docker inspect -f '{{.State.Health.Status}}')
+              if [ "$status" = "healthy" ]; then
+                echo "Container is healthy"
+                exit 0
+              fi
+              sleep 5
+              timeout=$((timeout-5))
+            done
+            
+            echo "Container did not become healthy within timeout"
+            docker-compose logs app
+            exit 1
+
+      - name: Notify Rollbar of deployment
+        uses: rollbar/github-deploy-action@2.1.2
+        with:
+          environment: ${{ env.ENVIRONMENT }}
+          version: ${{ github.sha }}
+          status: "succeeded"
+          local_username: ${{ github.actor }}
+        env:
+          ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+          ROLLBAR_USERNAME: "aaasante"

--- a/docs/proposals-and-projects/health-check-endpoint.ts
+++ b/docs/proposals-and-projects/health-check-endpoint.ts
@@ -1,0 +1,88 @@
+// Implementation of a health check endpoint for Docker health checks
+// This file should be placed in src/api/routes/
+
+import { JsonController, Get } from "routing-controllers";
+import { getRepository } from "typeorm";
+import { User } from "../../models/user";
+import { PrismaClient } from "@prisma/client";
+import { redisClient } from "../../bootstrap/express";
+import logger from "../../bootstrap/logger";
+
+@JsonController("/health")
+export class HealthCheckController {
+    @Get("/")
+    public async getHealth(): Promise<Record<string, unknown>> {
+        const health = {
+            uptime: process.uptime(),
+            timestamp: Date.now(),
+            status: "ok",
+            checks: {
+                database: { status: "pending", responseTime: 0 },
+                prisma: { status: "pending", responseTime: 0 },
+                redis: { status: "pending", responseTime: 0 }
+            }
+        };
+
+        try {
+            // TypeORM database check
+            const startTypeOrm = Date.now();
+            await getRepository(User).count();
+            health.checks.database = { 
+                status: "ok",
+                responseTime: Date.now() - startTypeOrm
+            };
+        } catch (error) {
+            logger.error("Health check - TypeORM database error:", error);
+            health.checks.database = { 
+                status: "error",
+                responseTime: 0,
+                error: error instanceof Error ? error.message : String(error)
+            };
+            health.status = "error";
+        }
+
+        try {
+            // Prisma database check
+            const prisma = new PrismaClient();
+            const startPrisma = Date.now();
+            await prisma.user.count();
+            health.checks.prisma = { 
+                status: "ok",
+                responseTime: Date.now() - startPrisma
+            };
+            await prisma.$disconnect();
+        } catch (error) {
+            logger.error("Health check - Prisma database error:", error);
+            health.checks.prisma = { 
+                status: "error",
+                responseTime: 0,
+                error: error instanceof Error ? error.message : String(error)
+            };
+            health.status = "error";
+        }
+
+        try {
+            // Redis check
+            const startRedis = Date.now();
+            const pingCommand = await redisClient.ping();
+            health.checks.redis = { 
+                status: pingCommand === "PONG" ? "ok" : "error",
+                responseTime: Date.now() - startRedis,
+                response: pingCommand
+            };
+            if (pingCommand !== "PONG") {
+                health.status = "error";
+            }
+        } catch (error) {
+            logger.error("Health check - Redis error:", error);
+            health.checks.redis = { 
+                status: "error",
+                responseTime: 0,
+                error: error instanceof Error ? error.message : String(error)
+            };
+            health.status = "error";
+        }
+
+        return health;
+    }
+}

--- a/docs/proposals-and-projects/postgres_redis_docker_migration.md
+++ b/docs/proposals-and-projects/postgres_redis_docker_migration.md
@@ -1,0 +1,185 @@
+# PostgreSQL and Redis Migration to Docker Plan
+
+This document outlines the step-by-step process to migrate your existing host-based PostgreSQL and Redis services to Docker containers while ensuring no data loss.
+
+## 1. Preparation
+
+- [ ] Create backup directory
+```bash
+mkdir -p ~/database_migration_backups
+```
+
+- [ ] Check current PostgreSQL and Redis versions on host
+```bash
+psql --version
+redis-cli info | grep version
+```
+
+## 2. PostgreSQL Migration
+
+### 2.1 Backup PostgreSQL Data
+
+- [ ] Create a full database dump
+```bash
+pg_dump -h localhost -U $PG_USER $PG_DB > ~/database_migration_backups/postgres_backup.sql
+```
+
+### 2.2 Update Docker Compose File
+
+- [ ] Add PostgreSQL service to your docker-compose.staging.yml
+```yaml
+postgres:
+  image: postgres:15  # Match your current version
+  container_name: staging_postgres
+  restart: always
+  environment:
+    - POSTGRES_PASSWORD=${PG_PASSWORD}
+    - POSTGRES_USER=${PG_USER}
+    - POSTGRES_DB=${PG_DB}
+  volumes:
+    - postgres_data:/var/lib/postgresql/data
+  ports:
+    - "5432:5432"
+  healthcheck:
+    test: ["CMD-SHELL", "pg_isready -U ${PG_USER} -d ${PG_DB}"]
+    interval: 10s
+    timeout: 5s
+    retries: 5
+    start_period: 10s
+```
+
+- [ ] Add volume definition
+```yaml
+volumes:
+  postgres_data:
+```
+
+### 2.3 Update App Configuration
+
+- [ ] Update app environment variables in docker-compose.staging.yml
+```yaml
+environment:
+  # Existing environment variables...
+  - PG_HOST=postgres  # Change from localhost to container service name
+```
+
+## 3. Redis Migration
+
+### 3.1 Backup Redis Data
+
+- [ ] Force a Redis save and copy RDB file
+```bash
+redis-cli SAVE
+cp /var/lib/redis/dump.rdb ~/database_migration_backups/dump.rdb
+```
+
+### 3.2 Update Docker Compose File
+
+- [ ] Add Redis service to your docker-compose.staging.yml
+```yaml
+redis:
+  image: redis:7  # Match your current version
+  container_name: staging_redis
+  restart: always
+  command: redis-server --appendonly yes
+  volumes:
+    - redis_data:/data
+  ports:
+    - "6379:6379"
+  healthcheck:
+    test: ["CMD", "redis-cli", "ping"]
+    interval: 5s
+    timeout: 3s
+    retries: 5
+    start_period: 10s
+```
+
+- [ ] Add volume definition (if not already added)
+```yaml
+volumes:
+  redis_data:
+```
+
+### 3.3 Update App Configuration
+
+- [ ] Update app environment variables in docker-compose.staging.yml
+```yaml
+environment:
+  # Existing environment variables...
+  - REDIS_HOST=redis  # Change from localhost to container service name
+```
+
+## 4. Service Dependencies
+
+- [ ] Add service dependencies in docker-compose.staging.yml
+```yaml
+depends_on:
+  postgres:
+    condition: service_healthy
+  redis:
+    condition: service_healthy
+```
+
+## 5. Deployment and Data Restoration
+
+### 5.1 Update Deployment Workflow
+
+- [ ] Ensure your GitHub Actions deployment workflow pulls and starts all services
+```yaml
+# Update docker-deploy.yml
+docker compose pull
+docker compose up -d
+```
+
+### 5.2 Restore PostgreSQL Data (First Deployment Only)
+
+- [ ] Connect to your server and restore the PostgreSQL data
+```bash
+cat ~/database_migration_backups/postgres_backup.sql | docker exec -i staging_postgres psql -U $PG_USER -d $PG_DB
+```
+
+### 5.3 Restore Redis Data (First Deployment Only, If Needed)
+
+- [ ] Copy the Redis dump file to the container and restart Redis
+```bash
+docker cp ~/database_migration_backups/dump.rdb staging_redis:/data/dump.rdb
+docker restart staging_redis
+```
+
+## 6. Verification
+
+- [ ] Verify PostgreSQL data
+```bash
+docker exec -it staging_postgres psql -U $PG_USER -d $PG_DB -c 'SELECT COUNT(*) FROM users;'
+```
+
+- [ ] Verify Redis connection
+```bash
+docker exec -it staging_redis redis-cli ping
+```
+
+- [ ] Check application logs for database connection errors
+```bash
+docker logs staging_trademachine
+```
+
+## 7. Cleanup (After Successful Migration)
+
+- [ ] Once everything is verified and working correctly, you can stop the host services
+```bash
+# Stop PostgreSQL on host (use appropriate command for your system)
+sudo systemctl stop postgresql
+
+# Stop Redis on host
+sudo systemctl stop redis
+```
+
+- [ ] Keep backups for a reasonable period before removing them
+
+## Notes
+
+1. Ensure your environment variables in the `.env` file are correctly set
+2. Consider a maintenance window for the migration to minimize disruption
+3. The migration assumes your schemas and database users are properly configured
+4. The docker-compose file assumes the .env file contains all necessary database credentials
+5. Update your GitHub Actions workflows to include pulling and starting all services

--- a/docs/proposals-and-projects/server-setup-guide.md
+++ b/docs/proposals-and-projects/server-setup-guide.md
@@ -1,0 +1,421 @@
+# Server Setup Guide for Docker Deployment
+
+This guide outlines the steps needed to set up a server for Docker-based deployment of the TradeMachine Server.
+
+## Prerequisites
+
+- Ubuntu 22.04 LTS server
+- SSH access with sudo privileges
+- Domain name pointing to the server
+
+## 1. Initial Server Setup
+
+### Update System
+
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+### Set Up Firewall
+
+```bash
+sudo apt install -y ufw
+sudo ufw allow ssh
+sudo ufw allow http
+sudo ufw allow https
+sudo ufw enable
+```
+
+### Install Basic Utilities
+
+```bash
+sudo apt install -y curl wget git htop tmux
+```
+
+## 2. Install Docker and Docker Compose
+
+### Install Docker
+
+```bash
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+sudo usermod -aG docker $USER
+```
+
+### Install Docker Compose
+
+```bash
+sudo apt install -y docker-compose-plugin
+```
+
+## 3. Application Directory Setup
+
+### Create Application Directories
+
+```bash
+sudo mkdir -p /opt/Apps/TradeMachine
+sudo mkdir -p /opt/Apps/StagingTradeMachine
+```
+
+### Set Permissions
+
+```bash
+sudo chown -R $USER:$USER /opt/Apps/TradeMachine
+sudo chown -R $USER:$USER /opt/Apps/StagingTradeMachine
+```
+
+## 4. Environment Configuration
+
+### Create Production Environment File
+
+```bash
+cd /opt/Apps/TradeMachine
+touch .env
+```
+
+Add the following variables to the .env file (replace with actual values):
+
+```
+# Application settings
+PORT=3000
+NODE_ENV=production
+ORM_CONFIG=production
+BASE_DIR=/app
+APP_ENV=production
+
+# Database settings
+DATABASE_URL=postgresql://username:password@host:port/trade_machine?schema=public
+PG_USER=username
+PG_PASSWORD=password
+PG_DB=trade_machine
+
+# Redis settings
+REDIS_IP=localhost
+REDIS_PORT=6379
+REDISPASS=your_redis_password
+SESSION_SECRET=your_session_secret
+
+# External services
+ROLLBAR_ACCESS_TOKEN=your_rollbar_token
+ROLLBAR_ENVIRONMENT=production
+```
+
+### Create Staging Environment File
+
+```bash
+cd /opt/Apps/StagingTradeMachine
+touch .env
+```
+
+Add similar variables with staging-specific values.
+
+## 5. Setup PostgreSQL (if not using existing instance)
+
+### Install PostgreSQL
+
+```bash
+sudo apt install -y postgresql postgresql-contrib
+```
+
+### Create Database and User
+
+```bash
+sudo -u postgres psql -c "CREATE DATABASE trade_machine;"
+sudo -u postgres psql -c "CREATE USER tm_user WITH ENCRYPTED PASSWORD 'your_password';"
+sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE trade_machine TO tm_user;"
+```
+
+### Setup Schemas
+
+```bash
+sudo -u postgres psql -d trade_machine -c "CREATE SCHEMA IF NOT EXISTS public;"
+sudo -u postgres psql -d trade_machine -c "CREATE SCHEMA IF NOT EXISTS staging;"
+sudo -u postgres psql -d trade_machine -c "GRANT ALL ON SCHEMA public TO tm_user;"
+sudo -u postgres psql -d trade_machine -c "GRANT ALL ON SCHEMA staging TO tm_user;"
+```
+
+## 6. Setup Redis (if not using existing instance)
+
+### Install Redis
+
+```bash
+sudo apt install -y redis-server
+```
+
+### Configure Redis
+
+Edit the Redis configuration file to enable password authentication:
+
+```bash
+sudo nano /etc/redis/redis.conf
+```
+
+Find the `requirepass` line and set a password:
+
+```
+requirepass your_redis_password
+```
+
+Restart Redis:
+
+```bash
+sudo systemctl restart redis
+```
+
+## 7. Configure Nginx as Reverse Proxy
+
+### Install Nginx
+
+```bash
+sudo apt install -y nginx
+```
+
+### Create Nginx Configuration
+
+For production:
+
+```bash
+sudo nano /etc/nginx/sites-available/trademachine
+```
+
+Add the following configuration:
+
+```nginx
+server {
+    listen 80;
+    server_name api.trades.example.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
+
+For staging:
+
+```bash
+sudo nano /etc/nginx/sites-available/staging-trademachine
+```
+
+Add similar configuration with different server_name.
+
+### Enable the Configurations
+
+```bash
+sudo ln -s /etc/nginx/sites-available/trademachine /etc/nginx/sites-enabled/
+sudo ln -s /etc/nginx/sites-available/staging-trademachine /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+## 8. Set Up SSL with Certbot
+
+### Install Certbot
+
+```bash
+sudo apt install -y certbot python3-certbot-nginx
+```
+
+### Obtain SSL Certificates
+
+For production:
+
+```bash
+sudo certbot --nginx -d api.trades.example.com
+```
+
+For staging:
+
+```bash
+sudo certbot --nginx -d staging-api.trades.example.com
+```
+
+## 9. Set Up Regular Backups
+
+### Create Backup Script
+
+```bash
+touch /opt/Apps/backup-db.sh
+chmod +x /opt/Apps/backup-db.sh
+```
+
+Add the following content:
+
+```bash
+#!/bin/bash
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BACKUP_DIR="/opt/Apps/backups"
+DB_NAME="trade_machine"
+SCHEMA=$1
+
+# Create backup directory if it doesn't exist
+mkdir -p $BACKUP_DIR
+
+# Backup database
+pg_dump -h localhost -U tm_user -n $SCHEMA $DB_NAME > $BACKUP_DIR/${DB_NAME}_${SCHEMA}_${TIMESTAMP}.sql
+
+# Compress backup
+gzip $BACKUP_DIR/${DB_NAME}_${SCHEMA}_${TIMESTAMP}.sql
+
+# Remove backups older than 15 days
+find $BACKUP_DIR -name "${DB_NAME}_${SCHEMA}_*.sql.gz" -type f -mtime +15 -delete
+```
+
+### Schedule Regular Backups
+
+```bash
+crontab -e
+```
+
+Add the following lines:
+
+```
+# Backup production database daily at 2:00 AM
+0 2 * * * /opt/Apps/backup-db.sh public
+
+# Backup staging database daily at 3:00 AM
+0 3 * * * /opt/Apps/backup-db.sh staging
+```
+
+## 10. Set Up Monitoring
+
+### Install Prometheus and Node Exporter
+
+```bash
+sudo apt install -y prometheus prometheus-node-exporter
+```
+
+### Configure Prometheus
+
+```bash
+sudo nano /etc/prometheus/prometheus.yml
+```
+
+Add the following job to the `scrape_configs` section:
+
+```yaml
+  - job_name: 'trademachine'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['localhost:3000']
+```
+
+Restart Prometheus:
+
+```bash
+sudo systemctl restart prometheus
+```
+
+### Install Grafana
+
+```bash
+sudo apt-get install -y apt-transport-https
+sudo apt-get install -y software-properties-common
+wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
+echo "deb https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+sudo apt-get update
+sudo apt-get install -y grafana
+sudo systemctl enable grafana-server
+sudo systemctl start grafana-server
+```
+
+## 11. Test the Setup
+
+### Test Nginx Configuration
+
+```bash
+curl -I https://api.trades.example.com
+```
+
+### Test Database Connection
+
+```bash
+docker run --rm --network host -e DATABASE_URL=postgresql://tm_user:your_password@localhost:5432/trade_machine?schema=public postgres:14 psql "$DATABASE_URL" -c "SELECT 1;"
+```
+
+### Test Redis Connection
+
+```bash
+docker run --rm --network host redis:6 redis-cli -h localhost -a your_redis_password ping
+```
+
+## 12. Security Recommendations
+
+1. **Configure Automatic Updates**:
+   ```bash
+   sudo apt install -y unattended-upgrades
+   sudo dpkg-reconfigure -plow unattended-upgrades
+   ```
+
+2. **Configure Fail2Ban**:
+   ```bash
+   sudo apt install -y fail2ban
+   sudo systemctl enable fail2ban
+   sudo systemctl start fail2ban
+   ```
+
+3. **Set Up SSH Key Authentication Only**:
+   ```bash
+   sudo nano /etc/ssh/sshd_config
+   ```
+   Set `PasswordAuthentication no` and restart SSH:
+   ```bash
+   sudo systemctl restart sshd
+   ```
+
+4. **Secure Docker**:
+   - Limit container resources
+   - Use Docker secrets for sensitive data
+   - Scan images for vulnerabilities:
+     ```bash
+     docker scan ghcr.io/yourusername/trade-machine:latest
+     ```
+
+## 13. Troubleshooting
+
+### Checking Container Logs
+
+```bash
+cd /opt/Apps/TradeMachine
+docker-compose logs -f app
+```
+
+### Checking Nginx Logs
+
+```bash
+sudo tail -f /var/log/nginx/access.log
+sudo tail -f /var/log/nginx/error.log
+```
+
+### Checking Container Health
+
+```bash
+cd /opt/Apps/TradeMachine
+docker-compose ps
+docker inspect $(docker-compose ps -q app) | grep -A 10 Health
+```
+
+### Restarting Services
+
+```bash
+# Restart the application container
+cd /opt/Apps/TradeMachine
+docker-compose restart app
+
+# Restart Nginx
+sudo systemctl restart nginx
+
+# Restart PostgreSQL
+sudo systemctl restart postgresql
+
+# Restart Redis
+sudo systemctl restart redis
+```

--- a/docs/proposals-and-projects/summary.md
+++ b/docs/proposals-and-projects/summary.md
@@ -1,0 +1,79 @@
+# TradeMachine Server Dockerization Plan Summary
+
+## Overview
+
+We have created a comprehensive plan for containerizing the TradeMachine Server application using Docker and implementing a modern CI/CD pipeline with GitHub Actions. This plan provides a roadmap for transitioning from the current PM2-based deployment to a container-based architecture, which will enhance scalability, portability, and maintainability.
+
+## Key Components Created
+
+1. **Dockerfile**: Multi-stage build process to create an optimized production image, with security considerations and health checks.
+
+2. **Docker Compose Setup**: Configuration for local development, including the Node.js application, PostgreSQL database, and Redis service.
+
+3. **GitHub Actions Workflows**:
+   - Build and publish workflow to create and push Docker images
+   - Deployment workflow to automate server updates
+
+4. **Server Setup Guide**: Detailed instructions for preparing a production server for Docker-based deployment, including installation of Docker, setting up databases, and configuring Nginx as a reverse proxy.
+
+5. **Documentation**: Comprehensive developer documentation for working with the Docker setup, including troubleshooting tips and advanced usage scenarios.
+
+6. **Additional Components**:
+   - Health check endpoint for container orchestration
+   - `.dockerignore` file to optimize build context
+
+## Implementation Plan
+
+The implementation roadmap is organized into phases:
+
+### Phase 1: Local Development Setup
+- Implement Dockerfile and docker-compose.yml
+- Test local development workflow
+- Create health check endpoint
+
+### Phase 2: CI/CD Pipeline Setup
+- Set up GitHub Container Registry
+- Implement build and publish workflow
+- Test image building and publishing
+
+### Phase 3: Server Setup
+- Install Docker and dependencies on production server
+- Configure environment variables
+- Set up Nginx reverse proxy and SSL
+
+### Phase 4: Production Deployment
+- Test staging deployment
+- Implement database migration process
+- Deploy to production
+
+### Phase 5: Optimization and Monitoring
+- Set up monitoring with Prometheus and Grafana
+- Implement log aggregation
+- Optimize container resource usage
+
+## Benefits of Dockerization
+
+1. **Consistency**: Development, testing, and production environments will be identical, reducing "works on my machine" issues.
+
+2. **Scalability**: Containers can be easily scaled horizontally as demand increases.
+
+3. **Isolation**: Each component runs in its own container, improving security and reducing conflicts.
+
+4. **Portability**: The application can be deployed on any infrastructure supporting Docker.
+
+5. **Efficiency**: Docker's layered filesystem and caching mechanisms optimize resource usage and deployment speed.
+
+6. **Simplified Operations**: Automated deployments reduce human error and operational overhead.
+
+7. **Improved CI/CD**: Containerized applications integrate well with modern CI/CD pipelines.
+
+## Next Steps
+
+1. Review the plan with the development team
+2. Implement changes incrementally, starting with local development
+3. Test thoroughly at each stage
+4. Gradually migrate production to the containerized version
+
+## Conclusion
+
+This dockerization plan provides a structured approach to modernizing the TradeMachine Server deployment process. By implementing this plan, the application will benefit from improved consistency, scalability, and maintainability, while also simplifying the development and deployment workflow.

--- a/docs/proposals-and-projects/trade-builder-api-proposal.md
+++ b/docs/proposals-and-projects/trade-builder-api-proposal.md
@@ -1,0 +1,245 @@
+# Trade Request Builder — Backend / v2 DAO Proposal
+
+Status: **Proposal / planning only — no code changes yet.**
+Audience: TradeMachineServer backend + the frontend team building the new Trade Request builder UI.
+
+## Scope & decisions baked into this doc
+
+These are settled for the first pass and the rest of the doc assumes them:
+
+- **tRPC v2 only.** The new UI talks to the v2 tRPC routers (`src/api/routes/v2/routers/`). We do **not** reach back into the legacy `TradeController` (routing-controllers) for create/edit, even though it technically already supports it. All new builder writes go into v2 `TradeDAO`.
+- **Single tenant / single league.** There is no `League` model and we are not adding one. Do **not** build `leagueId` scoping into the DAOs. Ignore every `/leagues/:leagueId/...` path and `leagueId` query param in the frontend mockups — they are dead weight here.
+- **Draft = `Trade.status = DRAFT`.** No separate "draft" table. The status enum already covers the lifecycle: `DRAFT → REQUESTED → PENDING → ACCEPTED / REJECTED → SUBMITTED`.
+- **Delete permissions:** an owner may delete **their own draft** (a `Trade` in `DRAFT` status that their team created). Deleting a trade in any other status remains **admin-only** (matches the current legacy behavior).
+- **Out of scope for v1 (commissioners handle manually during vetting):** "encumbered" assets (already in another pending trade) and roster-cap validation. See §6.
+- **No position filtering in v1.** Asset search will not filter/sort by position for the first pass; revisit later if needed. See §5.
+- **No optimistic concurrency in v1.** See §7.
+
+## The good news: the canonical model already exists
+
+The frontend's single most important ask — *"model trades as participants plus line items with `fromTeamId`/`toTeamId`, not give/get buckets"* — **is already how the schema works.** No contract change is needed to support V1/V2/V3 UX off one model.
+
+- `TradeParticipant` — `{ teamId, participantType: CREATOR | RECIPIENT }`, unique on `(tradeId, teamId)`.
+- `TradeItem` (the "line") — `{ id, tradeItemType: PLAYER | PICK, tradeItemId, senderId (fromTeam), recipientId (toTeam) }`, unique on `(tradeId, tradeItemId, tradeItemType, senderId, recipientId)`.
+
+> **What is `lineId`?** It is **not a new field.** A "line" in the mockups maps 1:1 to a `TradeItem` row, and `lineId` is that row's existing primary key — `TradeItem.id` (a UUID we already generate). The mock's `"line_1"` / `"L7"` are just placeholder display IDs; the real API uses the `TradeItem.id` UUID. No schema change for this.
+
+---
+
+## 1. `TradeDAO` — new functions (the core builder writes)
+
+The current v2 `TradeDAO` is **read + accept/decline/submit only** (`getTradeById`, `getTradesByTeam`, `getTradesPaginated`, `updateAcceptedBy`, `updateDeclinedBy`, `updateSubmitted`). It has **no create, no edit, no line mutations**. That is the main gap. None of the additions below require a schema migration (except the optional `title` column — see §7).
+
+| New function | Backs frontend asks | Notes |
+|---|---|---|
+| `createDraft({ creatorTeamId, participantTeamIds })` | `POST /trade-drafts` | Insert `Trade(status=DRAFT)` + `TradeParticipant` rows. Return the hydrated trade. |
+| `updateDraftParticipants(tradeId, participantTeamIds)` | `PATCH /trade-drafts` | Reconcile the participant set (add/remove). |
+| `addTradeItem(tradeId, { tradeItemType, tradeItemId, senderId, recipientId })` | `POST .../lines` | One line. The `@@unique(...)` constraint already dedupes identical lines. |
+| `updateTradeItem(lineId, { senderId?, recipientId? })` | `PATCH .../lines/:lineId` | Reroute a line (`lineId` = `TradeItem.id`). |
+| `removeTradeItem(lineId)` | `DELETE .../lines/:lineId` | |
+| `bulkMutateTradeItems(tradeId, { adds, updates, removes })` | `POST .../lines/bulk` | Nice-to-have; cuts chatty mobile calls. Wrap in a Prisma transaction. |
+| `deleteDraft(tradeId, requestingUserId)` | `DELETE /trade-drafts` | New. Authz: caller must be an owner of the creator team **and** status must be `DRAFT`. Any-other-status delete stays admin-only (existing legacy rule). |
+| `listDraftsForUser({ userId / teamIds, status, sort, skip, take })` | `GET /trade-drafts` | Thin wrapper over the existing `getTradesByTeam`, scoped to the requesting user's team(s) and `status=DRAFT`. Not a from-scratch build. |
+
+**Every mutation returns the fully hydrated trade.** The frontend explicitly asked for this to avoid refetches, and `getTradeById` already hydrates participants/items/teams/owners — reuse it as the return path for all of the above.
+
+---
+
+## 2. Builder search & lookup
+
+### Teams / owners picker (`GET /trade-builder/teams`)
+
+- **`TeamDAO.getAllTeams()` largely suffices.** It already returns each team's owners including `csvName`. For a single small league, the picker can filter client-side, or we add a thin `searchTeams({ q, excludeTeamIds })` server-side helper.
+- **What "search by ESPN name / CSV name" actually maps to (both possible):**
+  - **ESPN name** is just `Team.name` (it's the ESPN-synced name). Filtering/weighting on it = a plain `name ILIKE` on the `Team` table. The `name` column is already indexed (`@@index([name])` exists on `Player`; `Team.name` is a normal column — fine for a small league regardless).
+  - **CSV name** lives on `User`, not `Team`. All owners of a team should share the same `csvName`, so a team's CSV name = `team.owners[0]?.csvName`. Search = filter teams whose `owners.csvName ILIKE q` (a join/`some` filter on the owners relation). Good enough for v1.
+  - **`abbreviation` == `csvName`.** The "abbreviation" the mockups refer to (e.g. `BXB`) is the colloquial short name, which **is** `csvName` — not a separate field. So there is nothing extra to model; abbreviation search and CSV-name search are the same query.
+  - So the frontend's "match CSV name (== abbreviation) + ESPN name, CSV weighted highly" ask **is fully achievable** with existing data — a query across `Team.name` + the owners' `csvName`, with weighting applied in app code (or a `CASE`/ordering in SQL). The only piece that needs server-side logic is the weighting; the underlying data is all there.
+- **No missing columns for the team picker.** Every field the frontend asked for (ESPN name, CSV name / abbreviation, owner name) is already queryable.
+- Possible later (not v1, not required): denormalize `csvName` onto the `Team` table so it's a single real, indexable column instead of an owners-relation join. Purely a convenience/perf optimization — **not committing to that now**, and not needed for correctness.
+
+### Asset search — players (`GET /trade-builder/assets`)
+
+- **`PlayerDAO.searchPlayers({ search, league, skip, take })` exists** (name substring + MAJORS/MINORS + pagination).
+- **Enhance:** add an `ownerTeamIds[]` filter — the column already exists (`Player.leagueTeamId`) and is indexed.
+- **No position filtering in v1** (decided) — see §5.
+
+### Eligible picks (`GET /trade-builder/eligible-picks`)
+
+- **`DraftPickDAO.getAllPicks({ season, type })` exists** but does **not** filter by `round`, `originalOwnerId`, or `currentOwnerId` — even though the schema and indexes already support all three.
+- **New: `searchEligiblePicks({ year, type, round, originalOwnerId, currentOwnerId, skip, take })`** — straightforward and well-indexed (`@@index([currentOwnerId, originalOwnerId])`, `@@index([originalOwnerId])`, etc.). This is the cheap structured lookup the frontend (correctly) prefers over fuzzy pick search.
+- The "only return picks tradeable right now" default depends on a date — see §4.
+
+---
+
+## 3. Validation & review (`/validate`, `/review`)
+
+These are two "is this trade okay, and what does it look like?" calls at two different moments. They overlap heavily — implement them off **one** shared `buildTradeSummary(tradeId)` service so the send/receive counts are guaranteed identical across both (exactly the consistency the frontend asked for), then expose a lean slice and a full slice.
+
+### `POST .../validate` — "can I send this yet?" (callable anytime)
+
+A lightweight, repeatable legality check the builder calls *while the user is still editing* — drives the Send button's enabled/disabled state and inline errors/warnings as lines change. The mock includes a `mode` field (e.g. `"pre_review"`) so the same endpoint serves multiple points.
+
+Returns:
+```json
+{
+  "canSend": false,
+  "errors": [],
+  "warnings": [
+    { "code": "TEAM_RECEIVES_NOTHING", "message": "Curveball Crew receives nothing.", "teamId": "team_789" }
+  ],
+  "flowBalance": [
+    { "teamId": "team_123", "sendsCount": 2, "receivesCount": 1 }
+  ]
+}
+```
+
+What we compute in v1 (**structural + flow only**, the legacy `Trade.isValid()` logic surfaced as structured codes):
+- `errors` — exactly one `CREATOR` participant; ≥1 recipient; ≥1 line item.
+- `warnings` — e.g. `TEAM_RECEIVES_NOTHING` / a team that only sends or only receives, derived from per-team line counts.
+- `flowBalance` — per-team `sendsCount` / `receivesCount`, from grouping `TradeItem`s by `senderId` / `recipientId`.
+- `canSend` — `errors.length === 0`.
+
+### `POST .../review` — "show me the final review screen" (called once, before send)
+
+Returns the **canonical, human-readable summary** the user confirms on the review/confirm screen: the per-team breakdown of what's sent/received plus a notification preview. This is the frontend's *"server returns canonical summaries from lines"* ask.
+
+Returns:
+```json
+{
+  "draftId": "draft_abc",
+  "canSend": true,
+  "participants": [ /* team identity: name, csvName, owner */ ],
+  "sectionsByTeam": [
+    { "teamId": "team_123", "sends": [ /* hydrated assets */ ], "receives": [ /* hydrated assets */ ] }
+  ],
+  "notifications": { "willNotifyVia": ["email", "discord"] },
+  "validation": { "errors": [], "warnings": [] }
+}
+```
+
+What we compute in v1 (all from existing data — no new fields):
+- `sectionsByTeam` — a pure projection over the hydrated trade (`getTradeById` already hydrates items + teams + owners), grouping each line into the sender's `sends` and the recipient's `receives`.
+- `notifications.willNotifyVia` — read each recipient owner's `userSettings` prefs (`emailEnabled` / `discordDmEnabled` + presence of `discordUserId`); see §4.
+- `validation` — the same result as `/validate`.
+
+In short: **`/review` = `/validate` + the hydrated per-team sections + the notification preview.** `/validate` is the cheap call you can run on every line change; `/review` is the richer one-shot payload for the confirm screen.
+
+### Explicitly NOT in v1
+
+`ROSTER_LIMIT_EXCEEDED`, `PICK_ENCUMBERED` — no schema support; commissioners vet these manually. See §6.
+
+---
+
+## 4. Notifications, the trade window date, and Settings
+
+### Notifications on send — existing DAOs already cover it ✅
+
+- `ObanDAO` has everything: `enqueueTradeAnnouncement`, `enqueueTradeRequestEmail`, `enqueueTradeRequestDm`, plus accept/decline/submit variants.
+- `User` carries `discordUserId`, `slackUsername`, and `userSettings` (JSONB) with per-owner prefs (`emailEnabled` / `discordDmEnabled`). So `willNotifyVia` / `notifiedRecipients` are **computable today** — just a helper that reads recipient prefs. No new DAO.
+- The `send` action = the status→`REQUESTED` write (new `TradeDAO` work in §1) + existing `ObanDAO` enqueue.
+
+### Pick-trade deadline → move from env var into the `Settings` table (recommended)
+
+Today the "are picks tradeable yet this season" cutoff is a **date in frontend/backend env vars**, and the commissioner often doesn't hand you that date until mid-season — which means a redeploy to change it. The `Settings` table is the right home so commissioners/admins can self-serve:
+
+- The `Settings` model already exists (`tradeWindowStart` / `tradeWindowEnd` are `Time`-only and unused; `downtime` is JSON; `modifiedById` tracks who changed it).
+- **Proposal:** add a nullable `pickTradeEligibleFrom` (or per-`PickLeagueLevel` map) to `Settings`, editable via an admin/commissioner-only tRPC procedure. `searchEligiblePicks` reads it and, by default, returns no picks (or flags ineligible) until the date has passed.
+- This is a **small, self-contained migration** (one column on an existing table) and a natural fit — unlike roster caps, the data model already supports it. Worth doing because it removes a redeploy-to-change-a-date pain point.
+- **Until that lands:** `searchEligiblePicks` can keep reading the env var so the structured endpoint ships without blocking on the Settings work.
+
+---
+
+## 5. Position search — deferred (not in v1)
+
+**Decision: no position filtering or sorting in the first pass.** The notes below are captured for when we revisit it, but no work is planned now.
+
+Facts on the ground:
+
+- We're on **Postgres 16**.
+- `Player.meta` is mapped as plain **`json`** (Prisma `Json?`, no `@db.JsonB`) — **not `jsonb`**. Plain `json` can't take a GIN index and has limited operator support.
+- Position is **not** stored uniformly: for **minors** it's a string inside `meta`; for **majors** it's derived from a nested ESPN blob (`meta.espnPlayer...defaultPositionId` → mapped) and only surfaced as JSON in the `HydratedMajor` view (`eligiblePositions` / `mainPosition`, cast to `jsonb` in the view). The `HydratedMinor` view exposes `position` as `text`.
+
+Options, worst → best for our case:
+
+1. **Do nothing / filter in app code.** Fine only if result sets are tiny. Can't index, can't sort efficiently.
+2. **Expression (functional) index on the extracted value**, e.g. `CREATE INDEX ... ON player ((meta->>'position'))`. The `->>` operator works on `json` too, so this is possible without converting the column — **but** it only helps the *minors* shape; majors store position nested/differently, so one expression won't cover both leagues. Half a solution.
+3. **Convert `meta` to `jsonb`** (migration) and add a GIN or expression index. Enables richer JSON querying, but you still have the majors-vs-minors shape mismatch, and you'd be indexing an unstructured blob.
+4. **(Recommended) Promote `position` to a first-class `text` column on `Player`, B-tree indexed.** Both sync paths (ESPN majors, Sheets/NocoDB minors) populate it, backfilled once from existing `meta`. This is the clean, fast answer: simple `WHERE position = ?` / `IN (...)`, sortable, one index, no JSON gymnastics, and it sidesteps the two-shapes problem by normalizing at write time. This is the same "probably worth denormalizing" note already in the schema comment on `meta`.
+
+**If/when we do this later:** option 4 (promote `position` to a first-class indexed column) is the clean answer. Avoid option 2 as a "fix" — it silently only works for minors. For now this is deferred entirely.
+
+---
+
+## 6. Deliberately deferred (commissioners handle manually for now)
+
+Per decision, v1 does **not** implement these; commissioners continue to catch them when vetting trades:
+
+- **Encumbrance** ("asset is already in another pending trade"). Not modeled. *Could* be derived by joining `TradeItem` to non-terminal trades, but it's a new cross-table query and easy to race — skip it.
+- **Roster caps.** There is **no roster-size concept anywhere in the schema** (no roster table, no cap field). `ROSTER_LIMIT_EXCEEDED` / `rosterAfter` / `rosterCap` are not computable and would require a substantial schema project. Out of scope.
+
+The frontend should **not** design a validation card around roster legality for v1.
+
+---
+
+## 7. Optimistic concurrency — deferred (not in v1)
+
+**Decision: skip for the first pass.** Rationale below, kept for when multi-editor scenarios become real.
+
+**What it would be:** add a `version` integer (or use `dateModified` as a token) to a mutable row; every write sends `expectedVersion`; the server rejects with `409 CONFLICT` if the row changed since the client last read it, instead of silently overwriting (last-write-wins).
+
+**Why you'd want it / when it bites:** the builder autosaves frequently. Two writers on the *same draft* can clobber each other:
+- the same owner with the draft open in two tabs / on phone + laptop, or
+- a commissioner/admin editing a draft while the owner is also editing.
+
+Without versioning, whoever saves last wins and the other's edits vanish with no warning. With it, the client gets a 409 and can reconcile.
+
+**Which table:** only **`Trade`** (the draft). Line mutations (`TradeItem`) all happen in the context of a draft, so a single version on the parent `Trade` is sufficient — you don't need it on `TradeItem` or `TradeParticipant`.
+
+**Verdict for v1: skip it.** Drafts are overwhelmingly edited by a single owner in one place, and the blast radius of a lost autosave on a not-yet-sent draft is low. If/when multi-tab or commissioner-co-editing becomes real, `Trade.dateModified` already exists and can serve as a weak compare-and-set token without a migration; a dedicated `version` column can come later. Not worth blocking v1.
+
+---
+
+## 8. Per-team `eligibleAssetCount` / `lastTradedAt`
+
+Derivable (aggregate/join) but not stored. Fine to compute on demand for a single team detail view. **Not** something to put in a paginated team-search list without precompute/caching. Acceptable to defer for v1.
+
+---
+
+## 9. What existing v2 DAOs already cover (no new work)
+
+- **Load a draft / proposal:** `TradeDAO.getTradeById` (fully hydrated). ✅
+- **List trades for a team / staff:** `getTradesByTeam`, `getTradesPaginated` (status/date/player/pick filters). ✅ — `listDraftsForUser` is a thin wrapper.
+- **Accept / decline / submit:** `updateAcceptedBy`, `updateDeclinedBy`, `updateSubmitted` + existing v2 `trade` router procedures. ✅
+- **User/team identity for a `/me`-style bootstrap:** `UserDAO.getUserById` / `getAllUsersWithTeams`, `TeamDAO.getTeamById`. ✅ (a `builderContext` convenience procedure is composable from these — optional).
+- **Team + owner list (incl. `csvName`):** `TeamDAO.getAllTeams`. ✅
+- **Basic player search:** `PlayerDAO.searchPlayers`. ✅ (needs the `ownerTeamIds` enhancement for the full ask).
+- **Structured pick list by season/type:** `DraftPickDAO.getAllPicks`. ✅ partially (needs `searchEligiblePicks` for round/owner + date eligibility).
+- **All notification enqueueing:** `ObanDAO`. ✅ complete.
+
+---
+
+## 10. Recommended first-pass order
+
+1. **`TradeDAO` builder writes:** `createDraft`, `addTradeItem`, `updateTradeItem`, `removeTradeItem`, `updateDraftParticipants`, `listDraftsForUser`, `deleteDraft` (owner-can-delete-own-draft authz). *(zero migration)*
+2. **`DraftPickDAO.searchEligiblePicks`** (structured, indexed). *(zero migration)*
+3. **`PlayerDAO.searchPlayers`** enhancement: add `ownerTeamIds`. *(zero migration)*
+4. **`validateTrade`** (structural + flow balance only). *(zero migration)*
+5. **`send`:** status→`REQUESTED` write + existing `ObanDAO` enqueue + `willNotifyVia` helper. *(zero migration)*
+6. **Settings-driven pick-trade date** (small migration on `Settings` + admin/commissioner procedure). Until then, read the env var.
+
+Optional / later (explicitly **not** v1): a single `title` column on `Trade` for draft titles (small migration), `csvName` onto `Team`, `position` as a first-class column (§5), optimistic-concurrency `version` (§7).
+
+---
+
+## Migration summary
+
+| Change | Size | When |
+|---|---|---|
+| (none for builder CRUD, search, validate, send) | — | v1 — these are pure DAO additions |
+| `Settings.pickTradeEligibleFrom` | small (1 col, existing table) | recommended v1 follow-up; removes redeploy-to-change-a-date pain |
+| `Trade.title` | small (1 col) | optional v1 if draft titles are wanted |
+| `Player.position` first-class column + backfill + sync change | medium | **deferred — not v1** (§5) |
+| `Team.csvName` denormalization | medium (touches sync/display) | future, not committed |
+| `Trade.version` (optimistic concurrency) | small, but needs client contract | **deferred — not v1** (§7) |
+| Roster caps / encumbrance modeling | large | out of scope; commissioners vet manually (§6) |

--- a/docs/proposals-and-projects/ts-ed-migration-plan.md
+++ b/docs/proposals-and-projects/ts-ed-migration-plan.md
@@ -1,0 +1,210 @@
+# Migration Plan: routing-controllers to Ts.ED
+
+## Overview
+
+This document outlines the plan to migrate the TradeMachineServer from routing-controllers to Ts.ED framework. Ts.ED provides a more comprehensive set of features including better dependency injection, middleware management, OpenAPI integration, and improved testing capabilities.
+
+## Table of Contents
+1. [Current Architecture Assessment](#current-architecture-assessment)
+2. [Ts.ED Features Overview](#ts-ed-features-overview)
+3. [Migration Strategy Options](#migration-strategy-options)
+4. [Implementation Plan](#implementation-plan)
+5. [Shared Components Migration](#shared-components-migration)
+6. [Testing Strategy](#testing-strategy)
+7. [Rollout and Deployment](#rollout-and-deployment)
+8. [Monitoring and Fallback Strategy](#monitoring-and-fallback-strategy)
+9. [Timeline and Resources](#timeline-and-resources)
+
+## Current Architecture Assessment
+
+Before migration, we need to assess the current implementation:
+- Catalog all existing routes and controllers
+- Identify middleware and authentication mechanisms
+- Document current error handling approaches
+- Review current dependency injection patterns
+- Audit existing validation mechanisms
+
+## Ts.ED Features Overview
+
+Ts.ED offers several advantages over routing-controllers:
+- Better dependency injection system using `@tsed/di`
+- More comprehensive middleware support
+- Native OpenAPI/Swagger integration
+- More robust error handling
+- Better testing utilities
+- Support for multiple protocols (Express, Koa)
+
+## Migration Strategy Options
+
+### Option 1: Side-by-Side Servers
+- Run two separate server instances, each with its own port
+- Gradually migrate endpoints from old to new server
+- Use a proxy (like nginx) to route traffic between servers
+- **Pros**: Clear separation, independent scaling
+- **Cons**: More complex infrastructure, potential consistency issues
+
+### Option 2: Path-Based Migration (/v2)
+- Run both frameworks within same Express application
+- Use routing-controllers for existing endpoints and Ts.ED for /v2/* endpoints
+- Gradually migrate endpoints and move them to v2
+- Eventually phase out routing-controllers
+- **Pros**: Simpler infrastructure, shared resources
+- **Cons**: Potential conflicts between frameworks
+
+### Option 3: Incremental, In-Place Migration
+- Set up Ts.ED alongside routing-controllers in same Express app
+- Migrate controllers one by one, keeping same routes
+- Use feature flags to switch between implementations
+- **Pros**: Seamless to clients, no versioning needed
+- **Cons**: More complex code, potential conflicts
+
+### Recommended Approach
+
+We recommend **Option 2: Path-Based Migration** for the following reasons:
+1. Clearer separation of concerns during migration
+2. Ability to run both frameworks side-by-side without additional infrastructure
+3. Clear versioning for API consumers
+4. Simpler rollback strategy
+5. Gradual adoption path
+
+## Implementation Plan
+
+### Phase 1: Setup and Infrastructure
+1. Install Ts.ED dependencies
+2. Configure basic Ts.ED server under /v2 path
+3. Set up shared middleware and authentication
+4. Configure OpenAPI documentation
+5. Create sample controller to verify setup
+
+### Phase 2: Core Services Migration
+1. Identify core services to migrate first
+2. Implement new controllers in Ts.ED
+3. Setup proper dependency injection for services
+4. Implement necessary DTOs (Data Transfer Objects)
+5. Update validation using Ts.ED validation pipe
+
+### Phase 3: Incremental Endpoint Migration
+1. Prioritize endpoints by usage/importance
+2. Create corresponding Ts.ED controllers
+3. Implement comprehensive tests
+4. Update client to use new endpoints
+5. Monitor for issues
+
+### Phase 4: Cleanup and Finalization
+1. Remove routing-controllers dependencies
+2. Clean up deprecated code
+3. Consolidate documentation
+4. Finalize OpenAPI specs
+5. Consider removing /v2 prefix once migration is complete
+
+## Shared Components Migration
+
+### Authentication
+1. Implement Ts.ED authentication guards
+2. Ensure JWT/session handling works identically
+3. Migrate role-based access controls
+
+### Error Handling
+1. Create custom error filters in Ts.ED
+2. Ensure error responses match existing format
+
+### Validation
+1. Move from class-validator to Ts.ED validation pipes
+2. Ensure validation error messages are consistent
+
+### Middleware
+1. Convert Express middleware to Ts.ED middleware
+2. Ensure middleware execution order is preserved
+
+## Testing Strategy
+
+1. Create parallel test suite for Ts.ED controllers
+2. Ensure all endpoints have feature parity
+3. Implement integration tests for both implementations
+4. Consider A/B testing for critical endpoints
+
+## Rollout and Deployment
+
+1. Deploy with both frameworks enabled
+2. Gradually introduce Ts.ED endpoints to clients
+3. Monitor for issues and performance differences
+4. Once stable, deprecate routing-controllers endpoints
+
+## Monitoring and Fallback Strategy
+
+1. Implement comprehensive logging for both implementations
+2. Set up alerting for error rate differences
+3. Create fallback mechanism to routing-controllers if issues arise
+4. Monitor performance metrics for both frameworks
+
+## Timeline and Resources
+
+### Estimated Timeline
+- Phase 1 (Setup): 1-2 weeks
+- Phase 2 (Core Services): 2-3 weeks
+- Phase 3 (Incremental Migration): 4-8 weeks (depending on codebase size)
+- Phase 4 (Cleanup): 1-2 weeks
+
+### Resources Required
+- Dedicated developer(s) for migration work
+- Testing resources for validation
+- Documentation updates
+- Client coordination for endpoint changes
+
+## Code Example: Ts.ED Basic Setup
+
+```typescript
+import {Configuration, Inject} from '@tsed/di';
+import {PlatformApplication} from '@tsed/common';
+import express from 'express';
+import path from 'path';
+import {Server} from './server';
+
+@Configuration({
+  rootDir: __dirname,
+  mount: {
+    '/v2/api': [`${__dirname}/controllers/**/*.ts`]
+  },
+  componentsScan: [
+    `${__dirname}/services/**/*.ts`,
+    `${__dirname}/middleware/**/*.ts`
+  ],
+  middlewares: [
+    'cors',
+    'cookie-parser',
+    'compression',
+    'method-override',
+    'json-parser',
+    {use: 'urlencoded-parser', options: {extended: true}}
+  ]
+})
+export class App {
+  @Inject()
+  app: PlatformApplication;
+
+  @Configuration()
+  settings: Configuration;
+
+  $beforeRoutesInit(): void {
+    this.app
+      .use(express.json())
+      .use(express.urlencoded({extended: true}));
+  }
+}
+
+async function bootstrap() {
+  try {
+    const server = await Server.bootstrap(App);
+    await server.listen();
+    console.log('Server started...');
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+bootstrap();
+```
+
+## Conclusion
+
+Migrating from routing-controllers to Ts.ED represents a significant architectural improvement for the TradeMachineServer. By following a path-based migration strategy, we can minimize disruption while gradually introducing the new framework. The comprehensive features of Ts.ED will provide better long-term maintainability, improved developer experience, and more robust API documentation.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,268 @@
+# Testing Guide — Prisma (v2) DAOs
+
+How we write and run tests for the Prisma-based v2 DAOs (`src/DAO/v2/`). Read this before adding a new DAO class or DAO method so your tests match the house style without reverse-engineering existing ones.
+
+> Scope: this guide is about the **v2 / Prisma** DAOs. The legacy TypeORM DAOs in `src/DAO/` follow older patterns; new work should be Prisma + the v2 DAO pattern (see the repo-root `AGENTS.md`).
+
+---
+
+## 1. Where things live
+
+| Thing | Path |
+|---|---|
+| v2 DAOs under test | `src/DAO/v2/*.ts` |
+| v2 DAO **unit** tests | `tests/unit/DAO/v2/*.test.ts` |
+| Shared unit-test helpers | `tests/unit/DAO/v2/daoTestHelpers.ts` |
+| Data factories | `tests/factories/*.ts` |
+| Integration tests | `tests/integration/**/*.test.ts` |
+| Integration helpers (login, request, DB reset) | `tests/integration/helpers.ts` |
+| Extended Prisma client | `src/bootstrap/prisma-db.ts` |
+| Jest config | `jest.config.js` (testMatch: `*.test.ts` / `*.spec.ts`) |
+
+---
+
+## 2. Unit vs. integration — pick the right one
+
+We test DAOs at **both** layers, and they have opposite rules:
+
+| | Unit (`tests/unit/DAO/v2/`) | Integration (`tests/integration/`) |
+|---|---|---|
+| Prisma | **Mocked** (`jest-mock-extended`) | **Real** Postgres connection |
+| Mocks | Mock the Prisma delegate (one layer down) | **No mocks** — exercise the real query |
+| Asserts | The DAO passes the right `where`/`include`/`data` to Prisma | The DAO returns the right rows from a real DB |
+| Needs Docker/DB | **No** | **Yes** (Postgres + the `test` schema) |
+| Speed | Fast | Slower, run serially (`--runInBand`) |
+
+Rule of thumb (also in `AGENTS.md`): **mock one layer down from the code under test.** For a DAO that means mocking the Prisma model delegate. For a controller, mock the DAO. Integration tests mock nothing.
+
+A new DAO method should get **unit** coverage at minimum; add an integration test when the query is non-trivial (relation filters, raw SQL, pagination, ordering) and you want to prove it against a real database.
+
+---
+
+## 3. Running tests
+
+### Unit tests — no Docker needed
+
+```bash
+# all unit tests
+make test-unit
+
+# a single file
+make test-file        # prompts for the path
+# or directly:
+NODE_ENV=test ORM_CONFIG=local-test npx jest --config ./jest.config.js \
+  --detectOpenHandles --bail --forceExit --testPathPattern="tests/unit/DAO/v2/UserDAO"
+
+# a single test by name (regex), optionally combined with --testPathPattern
+NODE_ENV=test ORM_CONFIG=local-test npx jest --config ./jest.config.js \
+  --detectOpenHandles --bail --forceExit --testNamePattern="should strip the password"
+
+# watch mode
+make test-watch
+```
+
+### Integration tests — require Postgres + the `test` schema
+
+One-time / when infra isn't running:
+
+```bash
+# 1. Start shared Postgres + Redis (from repo root or via make)
+make docker-infrastructure-up
+
+# 2. Create/upgrade the `test` schema (run once, and again after ANY new Prisma migration)
+make prisma-migrate-test
+#   - sources tests/.env (DATABASE_URL with ?schema=test) and runs `prisma migrate deploy`
+#   - use `make prisma-push-test` instead to force-reset a corrupted/out-of-sync test schema
+```
+
+Then:
+
+```bash
+make test-integration
+# integration tests MUST run serially; the make target already adds --runInBand.
+# Running directly:
+NODE_ENV=test ORM_CONFIG=local-test npx jest --config ./jest.config.js \
+  --detectOpenHandles --runInBand --bail --forceExit --testPathPattern="tests/integration/v2/TrpcRoutes"
+```
+
+### Everything / coverage
+
+```bash
+make fullcheck   # lint + format + typecheck (run before committing)
+NODE_ENV=test ORM_CONFIG=local-test npx jest --config ./jest.config.js \
+  --detectOpenHandles --bail --forceExit --coverage
+```
+
+Notes:
+- `--runInBand` is **required** for integration tests (shared DB → parallel runs corrupt each other). Unit tests run in parallel fine.
+- Set `DB_LOGS=true` to see Prisma query logging in integration tests.
+
+---
+
+## 4. How to import the (extended) Prisma client
+
+We do **not** use a bare `PrismaClient`. The app runs an **extended** client (`src/bootstrap/prisma-db.ts`) that adds computed result fields (e.g. `user.isAdmin()`). Always type/construct against that.
+
+- Type: `import { ExtendedPrismaClient } from "../../bootstrap/prisma-db";`
+- Real instance (integration / scripts): `import initializeDb from "../../bootstrap/prisma-db"; const prisma = initializeDb();`
+- In tRPC procedures, the client is on context: `ctx.prisma` (already extended).
+
+**DAOs take a single model delegate, not the whole client.** Controllers/routers construct them as `new UserDAO(prisma.user)`, `new ObanDAO(ctx.prisma.obanJob)`, etc. Your tests must mirror that — mock or pass the **delegate** (`prisma.user`), not the whole client.
+
+---
+
+## 5. Canonical Prisma DAO **unit** test
+
+This is the shape every `tests/unit/DAO/v2/*.test.ts` follows. Copy it.
+
+```ts
+import { mockDeep, mockClear } from "jest-mock-extended";
+import TeamDAO, { teamInclude } from "../../../../src/DAO/v2/TeamDAO";
+import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
+import { TeamFactory } from "../../../factories/TeamFactory";
+import { daoTestLifecycle, expectDaoRequiresPrismaClient } from "./daoTestHelpers";
+import { TeamStatus } from "@prisma/client";
+
+// Alias the factory's Prisma-shaped builder; the wrapper arrow avoids the
+// jest/unbound-method lint warning that a bare `= TeamFactory.x` reference triggers.
+const makeTeam = (...args: Parameters<typeof TeamFactory.getPrismaTeamWithOwners>) =>
+    TeamFactory.getPrismaTeamWithOwners(...args);
+
+describe("[PRISMA] TeamDAO", () => {
+    // Mock the DELEGATE, not the whole client. Type it via ExtendedPrismaClient["<model>"].
+    const prisma = mockDeep<ExtendedPrismaClient["team"]>();
+    const dao = new TeamDAO(prisma as unknown as ExtendedPrismaClient["team"]);
+
+    daoTestLifecycle("TEAM");          // the ~~~~~~PRISMA TEAM DAO TESTS BEGIN/COMPLETE~~~~~~ banners
+    afterEach(() => mockClear(prisma)); // reset mock between tests
+
+    expectDaoRequiresPrismaClient(TeamDAO, "TeamDAO"); // the constructor guard test
+
+    describe("getAllTeams", () => {
+        it("returns teams ordered by name with owners included", async () => {
+            const teams = [makeTeam({ name: "Alpha" }), makeTeam({ name: "Beta" })];
+            prisma.findMany.mockResolvedValueOnce(teams as any);
+
+            const result = await dao.getAllTeams();
+
+            // Assert the DAO called Prisma correctly. Reuse the include constant
+            // EXPORTED FROM THE DAO so the expectation can't drift from the query.
+            expect(prisma.findMany).toHaveBeenCalledWith({
+                orderBy: { name: "asc" },
+                include: teamInclude,
+            });
+            expect(result).toHaveLength(2);
+        });
+    });
+});
+```
+
+Key points:
+- **Mock the delegate** with `mockDeep<ExtendedPrismaClient["<model>"]>()`; construct the DAO with it.
+- **`mockClear` in `afterEach`** so call assertions don't leak between tests.
+- **Mock data comes from a factory** (`getPrisma*` variants return the DAO's exact return type), not hand-rolled object literals.
+- **Assert against the DAO's exported `include`/`select` constant** (e.g. `teamInclude`, `draftPickInclude`, `playerOwnerTeamInclude`) rather than re-typing the literal. If a DAO doesn't export its include yet and you're adding tests for it, export it (one `export` keyword) and import it.
+- Mocked return values are used as identity — their exact field set doesn't affect `toHaveBeenCalledWith`, which checks the args the DAO passed *in*.
+
+## 5b. Canonical Prisma DAO **integration** test
+
+```ts
+import { clearPrismaDb } from "../helpers";
+import initializeDb, { ExtendedPrismaClient } from "../../../src/bootstrap/prisma-db";
+import UserDAO from "../../../src/DAO/v2/UserDAO";
+import { UserFactory } from "../../factories/UserFactory";
+
+let prisma: ExtendedPrismaClient;
+let userDAO: UserDAO;
+
+beforeAll(() => {
+    prisma = initializeDb(process.env.DB_LOGS === "true"); // REAL connection to the `test` schema
+    userDAO = new UserDAO(prisma.user);                    // construct with the real delegate
+});
+afterAll(async () => {
+    await prisma.$disconnect();
+});
+afterEach(async () => {
+    await clearPrismaDb(prisma); // TRUNCATEs all tables between tests (see note below)
+});
+
+it("persists and reads back a user", async () => {
+    const [created] = await userDAO.createUsers([UserFactory.getPrismaUser({ email: "a@b.com" })]);
+    const found = await userDAO.getUserById(created.id);
+    expect(found.email).toBe("a@b.com");
+});
+```
+
+- **No mocks.** Use the real client and real factories; assert on real rows.
+- `clearPrismaDb(prisma)` truncates tables between tests. It intentionally **skips** `oban_jobs`, `typeorm_metadata`, `_prisma_migrations`, and `query-result-cache`. If your test creates Oban jobs, clean them up yourself.
+- The `test` schema must exist and be migrated first (`make prisma-migrate-test`).
+
+---
+
+## 6. Minimum tests for any new DAO
+
+When you add a **new DAO class**, include:
+1. **Constructor guard** — `expectDaoRequiresPrismaClient(YourDAO, "YourDAO")`. (The DAO constructor must throw if given no delegate; all v2 DAOs do.)
+2. The `daoTestLifecycle("YOUR ENTITY")` banners.
+3. At least one test per public method (see below).
+
+When you add a **new DAO method**, cover:
+1. **Happy path** — correct `where` / `include` / `data` / `orderBy` passed to Prisma, and the result is returned/shaped correctly.
+2. **Each optional filter / branch** — one test per conditional (e.g. "filters by X when provided", "omits X when empty", connect-vs-disconnect, defaults applied when args omitted).
+3. **Empty / not-found** behavior where the method can short-circuit (e.g. resolve-to-empty returning `{ items: [], total: 0 }` without hitting `findMany`).
+4. **Pagination & ordering** if the method paginates (`skip`/`take`, `orderBy` direction, and the `count` call).
+5. Add an **integration test** if the query is non-trivial (relation `some`/`every`, raw SQL, multi-table) — prove it against a real DB, not just the mock.
+
+---
+
+## 7. Available helpers & factories (look here before hand-rolling)
+
+**Unit-test helpers — `tests/unit/DAO/v2/daoTestHelpers.ts`:**
+- `daoTestLifecycle(name: string)` — registers the begin/complete debug banners.
+- `expectDaoRequiresPrismaClient(DaoClass, daoName)` — the standard constructor-guard `describe`/`it`.
+
+**Factories — `tests/factories/`** (prefer these over inline literals). Each entity exposes Prisma-shaped builders that return the DAO's own return type and accept an `overrides` object:
+- `UserFactory.getPrismaUser(overrides?)`
+- `PlayerFactory.getPrismaPlayer(overrides?)` and `getPrismaPlayerWithTeam(overrides?)`
+- `TeamFactory.getPrismaTeamWithOwners(overrides?)`
+- `DraftPickFactory.getPrismaPickWithTeams(overrides?)`
+- `TradeFactory.getPrismaTrade(overrides?)`
+- `ObanJobFactory.getMockJob(id?, state?)`
+- (legacy TypeORM-model builders like `UserFactory.getUser()` also exist — use the `getPrisma*` ones for v2 DAO tests.)
+
+**DAO-exported query shapes** (import in tests instead of re-typing the literal):
+- `teamInclude` (`TeamDAO`), `draftPickInclude` (`DraftPickDAO`), `playerOwnerTeamInclude` (`PlayerDAO`).
+
+If a builder/shape you need doesn't exist yet, **add it to the factory / export it from the DAO** rather than hand-rolling it inline — that's how the next person finds it.
+
+---
+
+## 8. Best practices & things to avoid
+
+**Do**
+- Mock exactly one layer down (delegate for DAO tests; DAO for controller tests).
+- Reset mocks in `afterEach` (`mockClear`).
+- Use factories + DAO-exported include constants so a query-shape change updates one place.
+- Keep `[PRISMA] <DAO>` describe titles and `daoTestLifecycle` banners consistent — they make local log output navigable.
+- Type mocks as `ExtendedPrismaClient["<model>"]`, matching how the DAO is really constructed.
+
+**Avoid**
+- ❌ Hand-rolling mock entities inline when a factory exists (or could). Drift and duplication.
+- ❌ Re-declaring a DAO's `include`/`select` literal in the test — import the exported constant.
+- ❌ Mocking a bare `PrismaClient` — you'll miss the extension (`isAdmin`, etc.). Use `ExtendedPrismaClient`.
+- ❌ Running integration tests in parallel — always `--runInBand` (the make target does this).
+- ❌ Adding mocks to integration tests — they must hit the real DB.
+- ❌ Deleting a failing test. If you truly can't fix it, comment it out with an `eslint-disable` and a clear TODO explaining why and how to restore it (see `AGENTS.md`).
+- ❌ Forgetting `make prisma-migrate-test` after adding a Prisma migration — integration tests will fail against a stale `test` schema.
+
+---
+
+## 9. Quick checklist for a new DAO
+
+- [ ] DAO constructor throws without a delegate; `expectDaoRequiresPrismaClient` test added.
+- [ ] `daoTestLifecycle("<ENTITY>")` + `[PRISMA] <DAO>` describe.
+- [ ] A `getPrisma<Entity>...` factory exists (add one if not) and is used for mock data.
+- [ ] Any reused `include`/`select` is a constant exported from the DAO and asserted via that import.
+- [ ] Every public method: happy path + each branch + empty/not-found + pagination/order where relevant.
+- [ ] Integration test added for non-trivial queries.
+- [ ] `make fullcheck` passes; unit tests green (and integration green if added).

--- a/src/DAO/v2/DraftPickDAO.ts
+++ b/src/DAO/v2/DraftPickDAO.ts
@@ -1,13 +1,19 @@
 import { Prisma, PickLeagueLevel } from "@prisma/client";
 import { ExtendedPrismaClient } from "../../bootstrap/prisma-db";
 
-const teamOwnerSelect = {
+export const teamOwnerSelect = {
     select: { id: true, name: true, espnId: true, status: true },
+} as const;
+
+/** The `include` clause used by every DraftPickDAO read that hydrates owner teams. */
+export const draftPickInclude = {
+    currentOwner: teamOwnerSelect,
+    originalOwner: teamOwnerSelect,
 } as const;
 
 export type DraftPickWithTeams = Prisma.Result<
     ExtendedPrismaClient["draftPick"],
-    { include: { currentOwner: typeof teamOwnerSelect; originalOwner: typeof teamOwnerSelect } },
+    { include: typeof draftPickInclude },
     "findFirstOrThrow"
 >;
 
@@ -29,14 +35,14 @@ export default class DraftPickDAO {
         return (await this.pickDb.findMany({
             where,
             orderBy: [{ season: "desc" }, { round: "asc" }, { pickNumber: "asc" }],
-            include: { currentOwner: teamOwnerSelect, originalOwner: teamOwnerSelect },
+            include: draftPickInclude,
         })) as unknown as DraftPickWithTeams[];
     }
 
     public async getPickById(id: string): Promise<DraftPickWithTeams> {
         return (await this.pickDb.findUniqueOrThrow({
             where: { id },
-            include: { currentOwner: teamOwnerSelect, originalOwner: teamOwnerSelect },
+            include: draftPickInclude,
         })) as unknown as DraftPickWithTeams;
     }
 
@@ -57,7 +63,7 @@ export default class DraftPickDAO {
                 currentOwnerId: data.currentOwnerId ?? null,
                 originalOwnerId: data.originalOwnerId ?? null,
             },
-            include: { currentOwner: teamOwnerSelect, originalOwner: teamOwnerSelect },
+            include: draftPickInclude,
         })) as unknown as DraftPickWithTeams;
     }
 
@@ -91,14 +97,14 @@ export default class DraftPickDAO {
         return (await this.pickDb.update({
             where: { id },
             data: updateData,
-            include: { currentOwner: teamOwnerSelect, originalOwner: teamOwnerSelect },
+            include: draftPickInclude,
         })) as unknown as DraftPickWithTeams;
     }
 
     public async deletePick(id: string): Promise<DraftPickWithTeams> {
         return (await this.pickDb.delete({
             where: { id },
-            include: { currentOwner: teamOwnerSelect, originalOwner: teamOwnerSelect },
+            include: draftPickInclude,
         })) as unknown as DraftPickWithTeams;
     }
 }

--- a/src/DAO/v2/PlayerDAO.ts
+++ b/src/DAO/v2/PlayerDAO.ts
@@ -8,6 +8,11 @@ export type PlayerWithTeam = Player & {
     ownerTeam: { id: string; name: string; owners: { csvName: string | null }[] } | null;
 };
 
+/** The `include` clause used by every PlayerDAO read/write that hydrates the owner team. */
+export const playerOwnerTeamInclude = {
+    ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } },
+} as const;
+
 export default class PlayerDAO {
     private readonly playerDb: ExtendedPrismaClient["player"];
 
@@ -40,7 +45,7 @@ export default class PlayerDAO {
                 orderBy: { name: "asc" },
                 skip: opts?.skip ?? 0,
                 take: opts?.take ?? 50,
-                include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
+                include: playerOwnerTeamInclude,
             }),
             this.playerDb.count({ where }),
         ]);
@@ -51,7 +56,7 @@ export default class PlayerDAO {
     public async getPlayerById(id: string): Promise<PlayerWithTeam> {
         return (await this.playerDb.findUniqueOrThrow({
             where: { id },
-            include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
+            include: playerOwnerTeamInclude,
         })) as unknown as PlayerWithTeam;
     }
 
@@ -70,7 +75,7 @@ export default class PlayerDAO {
                 playerDataId: data.playerDataId ?? null,
                 leagueTeamId: data.leagueTeamId ?? null,
             },
-            include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
+            include: playerOwnerTeamInclude,
         })) as unknown as PlayerWithTeam;
     }
 
@@ -87,7 +92,7 @@ export default class PlayerDAO {
         return (await this.playerDb.update({
             where: { id },
             data,
-            include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
+            include: playerOwnerTeamInclude,
         })) as unknown as PlayerWithTeam;
     }
 

--- a/src/DAO/v2/TeamDAO.ts
+++ b/src/DAO/v2/TeamDAO.ts
@@ -1,13 +1,16 @@
 import { Prisma, TeamStatus } from "@prisma/client";
 import { ExtendedPrismaClient } from "../../bootstrap/prisma-db";
 
-const ownersSelect = {
+export const ownersSelect = {
     select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
 } as const;
 
+/** The `include` clause used by every TeamDAO read/write that hydrates owners. */
+export const teamInclude = { owners: ownersSelect } as const;
+
 export type TeamWithOwners = Prisma.Result<
     ExtendedPrismaClient["team"],
-    { include: { owners: typeof ownersSelect } },
+    { include: typeof teamInclude },
     "findFirstOrThrow"
 >;
 
@@ -24,14 +27,14 @@ export default class TeamDAO {
     public async getAllTeams(): Promise<TeamWithOwners[]> {
         return (await this.teamDb.findMany({
             orderBy: { name: "asc" },
-            include: { owners: ownersSelect },
+            include: teamInclude,
         })) as unknown as TeamWithOwners[];
     }
 
     public async getTeamById(id: string): Promise<TeamWithOwners> {
         return (await this.teamDb.findUniqueOrThrow({
             where: { id },
-            include: { owners: ownersSelect },
+            include: teamInclude,
         })) as unknown as TeamWithOwners;
     }
 
@@ -46,7 +49,7 @@ export default class TeamDAO {
                 espnId: data.espnId ?? null,
                 status: data.status ?? TeamStatus.ACTIVE,
             },
-            include: { owners: ownersSelect },
+            include: teamInclude,
         })) as unknown as TeamWithOwners;
     }
 
@@ -57,14 +60,14 @@ export default class TeamDAO {
         return (await this.teamDb.update({
             where: { id },
             data,
-            include: { owners: ownersSelect },
+            include: teamInclude,
         })) as unknown as TeamWithOwners;
     }
 
     public async deleteTeam(id: string): Promise<TeamWithOwners> {
         return (await this.teamDb.delete({
             where: { id },
-            include: { owners: ownersSelect },
+            include: teamInclude,
         })) as unknown as TeamWithOwners;
     }
 }

--- a/tests/factories/DraftPickFactory.ts
+++ b/tests/factories/DraftPickFactory.ts
@@ -1,4 +1,6 @@
 import DraftPick, { LeagueLevel } from "../../src/models/draftPick";
+import { Prisma, PickLeagueLevel } from "@prisma/client";
+import type { DraftPickWithTeams } from "../../src/DAO/v2/DraftPickDAO";
 import { v4 as uuid } from "uuid";
 import { TeamFactory } from "./TeamFactory";
 import Team from "../../src/models/team";
@@ -24,5 +26,24 @@ export class DraftPickFactory {
         rest = {}
     ): DraftPick {
         return new DraftPick(DraftPickFactory.getPickObject(round, pickNumber, type, season, originalOwner, rest));
+    }
+
+    /** A pick hydrated with owner teams, matching `DraftPickDAO`'s `DraftPickWithTeams` return shape. */
+    public static getPrismaPickWithTeams(overrides: Partial<DraftPickWithTeams> = {}): DraftPickWithTeams {
+        return {
+            id: uuid(),
+            round: new Prisma.Decimal(1),
+            season: 2026,
+            type: PickLeagueLevel.MAJORS,
+            pickNumber: null,
+            currentOwnerId: null,
+            originalOwnerId: null,
+            currentOwner: null,
+            originalOwner: null,
+            lastSyncedAt: null,
+            dateCreated: new Date(),
+            dateModified: new Date(),
+            ...overrides,
+        } as unknown as DraftPickWithTeams;
     }
 }

--- a/tests/factories/ObanJobFactory.ts
+++ b/tests/factories/ObanJobFactory.ts
@@ -1,0 +1,16 @@
+import { oban_job_state } from "@prisma/client";
+
+/**
+ * Minimal mock Oban job rows for unit tests that assert on `obanJob.create(...)`
+ * calls. The DAO only ever reads `id`/`state` off the returned row, so this stub
+ * intentionally stays small. Replaces the inline `{ id: BigInt(n), state: ... }`
+ * literals scattered across the ObanDAO unit tests.
+ */
+export class ObanJobFactory {
+    public static getMockJob(
+        id = 1,
+        state: oban_job_state = oban_job_state.available
+    ): { id: bigint; state: oban_job_state } {
+        return { id: BigInt(id), state };
+    }
+}

--- a/tests/factories/PlayerFactory.ts
+++ b/tests/factories/PlayerFactory.ts
@@ -1,5 +1,6 @@
 import Player, { PlayerLeagueType } from "../../src/models/player";
 import { Player as PrismaPlayer, PlayerLeagueLevel } from "@prisma/client";
+import type { PlayerWithTeam } from "../../src/DAO/v2/PlayerDAO";
 import { v4 as uuid } from "uuid";
 import { faker } from "@faker-js/faker";
 
@@ -22,22 +23,28 @@ export class PlayerFactory {
         return new Player(PlayerFactory.getPlayerObject(name, league, rest));
     }
 
-    public static getPrismaPlayer(
-        name = faker.name.fullName(),
-        league = PlayerLeagueLevel.MINORS,
-        _rest = {}
-    ): PrismaPlayer {
+    public static getPrismaPlayer(overrides: Partial<PrismaPlayer> = {}): PrismaPlayer {
         return {
             id: uuid(),
             dateCreated: new Date(),
             dateModified: new Date(),
-            name,
-            league,
+            name: faker.name.fullName(),
+            league: PlayerLeagueLevel.MINORS,
             mlbTeam: null,
             meta: {},
             playerDataId: parseInt(faker.random.numeric(5), 10),
             lastSyncedAt: null,
             leagueTeamId: null,
+            ...overrides,
         };
+    }
+
+    /** A player hydrated with its owner team, matching `PlayerDAO`'s `PlayerWithTeam` return shape. */
+    public static getPrismaPlayerWithTeam(overrides: Partial<PlayerWithTeam> = {}): PlayerWithTeam {
+        return {
+            ...PlayerFactory.getPrismaPlayer(),
+            ownerTeam: null,
+            ...overrides,
+        } as PlayerWithTeam;
     }
 }

--- a/tests/factories/TeamFactory.ts
+++ b/tests/factories/TeamFactory.ts
@@ -1,5 +1,7 @@
 import { faker } from "@faker-js/faker";
+import { TeamStatus } from "@prisma/client";
 import Team from "../../src/models/team";
+import type { TeamWithOwners } from "../../src/DAO/v2/TeamDAO";
 import { v4 as uuid } from "uuid";
 import { espnIdCounter } from "./Counter";
 
@@ -34,5 +36,21 @@ export class TeamFactory {
             }
             return TeamFactory.getTeam(name, i + 1);
         });
+    }
+
+    /** A team hydrated with owners, matching `TeamDAO`'s `TeamWithOwners` return shape. */
+    public static getPrismaTeamWithOwners(overrides: Partial<TeamWithOwners> = {}): TeamWithOwners {
+        return {
+            id: uuid(),
+            name: TeamFactory.NAME,
+            espnId: 1,
+            status: TeamStatus.ACTIVE,
+            espnTeam: null,
+            lastSyncedAt: null,
+            dateCreated: new Date(),
+            dateModified: new Date(),
+            owners: [],
+            ...overrides,
+        } as unknown as TeamWithOwners;
     }
 }

--- a/tests/factories/TradeFactory.ts
+++ b/tests/factories/TradeFactory.ts
@@ -2,6 +2,8 @@ import { PlayerLeagueType } from "../../src/models/player";
 import Trade, { TradeStatus } from "../../src/models/trade";
 import TradeItem, { TradeItemType } from "../../src/models/tradeItem";
 import TradeParticipant, { TradeParticipantType } from "../../src/models/tradeParticipant";
+import { TradeStatus as PrismaTradeStatus } from "@prisma/client";
+import type { PrismaTrade } from "../../src/DAO/v2/TradeDAO";
 import { DraftPickFactory } from "./DraftPickFactory";
 import { PlayerFactory } from "./PlayerFactory";
 import { TeamFactory } from "./TeamFactory";
@@ -111,5 +113,29 @@ export class TradeFactory {
 
     public static getTradeRecipient(team?: Team, trade?: Trade): TradeParticipant {
         return new TradeParticipant({ id: uuid(), participantType: TradeParticipantType.RECIPIENT, trade, team });
+    }
+
+    /**
+     * A minimal Prisma-shaped trade matching `TradeDAO`'s `PrismaTrade` return shape.
+     * Relations default to empty; override as needed for a given test.
+     */
+    public static getPrismaTrade(overrides: Partial<PrismaTrade> = {}): PrismaTrade {
+        return {
+            id: uuid(),
+            dateCreated: new Date(),
+            dateModified: new Date(),
+            status: PrismaTradeStatus.REQUESTED,
+            declinedReason: null,
+            declinedById: null,
+            acceptedBy: null,
+            acceptedByDetails: null,
+            acceptedOnDate: null,
+            submittedAt: null,
+            submittedById: null,
+            tradeParticipants: [],
+            tradeItems: [],
+            emails: [],
+            ...overrides,
+        } as unknown as PrismaTrade;
     }
 }

--- a/tests/factories/UserFactory.ts
+++ b/tests/factories/UserFactory.ts
@@ -20,19 +20,13 @@ export class UserFactory {
         return { id: uuid(), email, displayName, password, role, ...rest };
     }
 
-    public static getPrismaUser(
-        email = UserFactory.TEST_EMAIL,
-        displayName = UserFactory.GENERIC_NAME,
-        password = UserFactory.GENERIC_PASSWORD,
-        role = UserRole.ADMIN,
-        rest = {}
-    ): PrismaUser {
+    public static getPrismaUser(overrides: Partial<PrismaUser> = {}): PrismaUser {
         return {
             id: uuid(),
-            email,
-            displayName,
-            password,
-            role,
+            email: UserFactory.TEST_EMAIL,
+            displayName: UserFactory.GENERIC_NAME,
+            password: UserFactory.GENERIC_PASSWORD,
+            role: UserRole.ADMIN,
             dateCreated: new Date(),
             dateModified: new Date(),
             slackUsername: null,
@@ -44,7 +38,8 @@ export class UserFactory {
             csvName: null,
             espnMember: null,
             teamId: null,
-            ...rest,
+            userSettings: null,
+            ...overrides,
         } as PrismaUser;
     }
 

--- a/tests/unit/DAO/v2/DraftPickDAO.test.ts
+++ b/tests/unit/DAO/v2/DraftPickDAO.test.ts
@@ -1,60 +1,25 @@
 import { mockDeep, mockClear } from "jest-mock-extended";
-import DraftPickDAO, { DraftPickWithTeams } from "../../../../src/DAO/v2/DraftPickDAO";
+import DraftPickDAO, { draftPickInclude } from "../../../../src/DAO/v2/DraftPickDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
-import logger from "../../../../src/bootstrap/logger";
+import { DraftPickFactory } from "../../../factories/DraftPickFactory";
+import { daoTestLifecycle, expectDaoRequiresPrismaClient } from "./daoTestHelpers";
 import { v4 as uuid } from "uuid";
 import { Prisma, PickLeagueLevel } from "@prisma/client";
 
-const makeTeamStub = (overrides: Record<string, unknown> = {}) => ({
-    id: uuid(),
-    name: "Test Team",
-    espnId: 1,
-    status: "ACTIVE",
-    ...overrides,
-});
-
-const makePick = (overrides: Record<string, unknown> = {}): DraftPickWithTeams =>
-    ({
-        id: uuid(),
-        round: new Prisma.Decimal(1),
-        season: 2026,
-        type: PickLeagueLevel.MAJORS,
-        pickNumber: null,
-        currentOwnerId: null,
-        originalOwnerId: null,
-        currentOwner: null,
-        originalOwner: null,
-        dateCreated: new Date(),
-        dateModified: new Date(),
-        ...overrides,
-    } as unknown as DraftPickWithTeams);
-
-const expectedInclude = {
-    currentOwner: { select: { id: true, name: true, espnId: true, status: true } },
-    originalOwner: { select: { id: true, name: true, espnId: true, status: true } },
-};
+const makePick = (...args: Parameters<typeof DraftPickFactory.getPrismaPickWithTeams>) =>
+    DraftPickFactory.getPrismaPickWithTeams(...args);
+const expectedInclude = draftPickInclude;
 
 describe("[PRISMA] DraftPickDAO", () => {
     const prisma = mockDeep<ExtendedPrismaClient["draftPick"]>();
     const dao = new DraftPickDAO(prisma as unknown as ExtendedPrismaClient["draftPick"]);
 
-    beforeAll(() => {
-        logger.debug("~~~~~~PRISMA DRAFTPICK DAO TESTS BEGIN~~~~~~");
-    });
-    afterAll(() => {
-        logger.debug("~~~~~~PRISMA DRAFTPICK DAO TESTS COMPLETE~~~~~~");
-    });
+    daoTestLifecycle("DRAFTPICK");
     afterEach(() => {
         mockClear(prisma);
     });
 
-    describe("constructor", () => {
-        it("should throw when initialized without a prisma client", () => {
-            expect(() => new DraftPickDAO(undefined)).toThrow(
-                "DraftPickDAO must be initialized with a PrismaClient model instance!"
-            );
-        });
-    });
+    expectDaoRequiresPrismaClient(DraftPickDAO, "DraftPickDAO");
 
     describe("getAllPicks", () => {
         it("should return all picks with team relations when no filters are provided", async () => {

--- a/tests/unit/DAO/v2/ObanDAO.sync.test.ts
+++ b/tests/unit/DAO/v2/ObanDAO.sync.test.ts
@@ -1,6 +1,7 @@
 import { mockDeep, mockClear } from "jest-mock-extended";
 import ObanDAO from "../../../../src/DAO/v2/ObanDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
+import { ObanJobFactory } from "../../../factories/ObanJobFactory";
 import { oban_job_state } from "@prisma/client";
 
 describe("ObanDAO Sync Enqueue Helpers", () => {
@@ -13,7 +14,7 @@ describe("ObanDAO Sync Enqueue Helpers", () => {
     });
 
     const traceContext = { traceparent: "00-abc-def-01", tracestate: "test=1" };
-    const mockJob = { id: BigInt(100), state: oban_job_state.available };
+    const mockJob = ObanJobFactory.getMockJob(100);
 
     describe("enqueueEspnTeamSync", () => {
         it("should enqueue with correct queue, worker, and max_attempts", async () => {

--- a/tests/unit/DAO/v2/ObanDAO.test.ts
+++ b/tests/unit/DAO/v2/ObanDAO.test.ts
@@ -1,7 +1,7 @@
 import { mockDeep, mockClear } from "jest-mock-extended";
 import ObanDAO from "../../../../src/DAO/v2/ObanDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
-import { oban_job_state } from "@prisma/client";
+import { ObanJobFactory } from "../../../factories/ObanJobFactory";
 
 describe("ObanDAO Unit Tests", () => {
     const mockPrismaObanJob = mockDeep<ExtendedPrismaClient["obanJob"]>();
@@ -32,7 +32,7 @@ describe("ObanDAO Unit Tests", () => {
             const userId = "user-123";
             const traceContext = { traceparent: "test-trace", tracestate: "test-state" };
 
-            const mockJob = { id: BigInt(1), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(1);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueuePasswordResetEmail(userId, traceContext);
@@ -54,7 +54,7 @@ describe("ObanDAO Unit Tests", () => {
 
             const userId = "user-456";
 
-            const mockJob = { id: BigInt(2), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(2);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueuePasswordResetEmail(userId);
@@ -75,7 +75,7 @@ describe("ObanDAO Unit Tests", () => {
 
             const userId = "user-789";
 
-            const mockJob = { id: BigInt(3), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(3);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueuePasswordResetEmail(userId);
@@ -96,7 +96,7 @@ describe("ObanDAO Unit Tests", () => {
 
             const userId = "user-dev";
 
-            const mockJob = { id: BigInt(4), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(4);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueuePasswordResetEmail(userId);
@@ -120,7 +120,7 @@ describe("ObanDAO Unit Tests", () => {
             const userId = "user-reg-123";
             const traceContext = { traceparent: "test-trace-reg" };
 
-            const mockJob = { id: BigInt(5), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(5);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueRegistrationEmail(userId, traceContext);
@@ -142,7 +142,7 @@ describe("ObanDAO Unit Tests", () => {
 
             const userId = "user-reg-456";
 
-            const mockJob = { id: BigInt(6), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(6);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueRegistrationEmail(userId);
@@ -163,7 +163,7 @@ describe("ObanDAO Unit Tests", () => {
 
             const userId = "user-reg-789";
 
-            const mockJob = { id: BigInt(7), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(7);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueRegistrationEmail(userId);
@@ -184,7 +184,7 @@ describe("ObanDAO Unit Tests", () => {
 
             const userId = "user-reg-dev";
 
-            const mockJob = { id: BigInt(8), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(8);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueRegistrationEmail(userId);
@@ -210,7 +210,7 @@ describe("ObanDAO Unit Tests", () => {
         it("should enqueue a trade_request email job with all required fields", async () => {
             process.env.APP_ENV = "staging";
 
-            const mockJob = { id: BigInt(20), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(20);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeRequestEmail(tradeId, recipientUserId, acceptUrl, declineUrl);
@@ -235,7 +235,7 @@ describe("ObanDAO Unit Tests", () => {
             process.env.APP_ENV = "production";
 
             const traceContext = { traceparent: "00-abc-def-01", tracestate: "grafana=abc" };
-            const mockJob = { id: BigInt(21), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(21);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeRequestEmail(tradeId, recipientUserId, acceptUrl, declineUrl, traceContext);
@@ -254,7 +254,7 @@ describe("ObanDAO Unit Tests", () => {
         it("should default env to staging when APP_ENV is not set", async () => {
             delete process.env.APP_ENV;
 
-            const mockJob = { id: BigInt(22), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(22);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeRequestEmail(tradeId, recipientUserId, acceptUrl, declineUrl);
@@ -280,7 +280,7 @@ describe("ObanDAO Unit Tests", () => {
                 tracestate: "grafana=sessionId:abc123",
             };
 
-            const mockJob = { id: BigInt(9), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(9);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeAnnouncement(tradeId, traceContext);
@@ -304,7 +304,7 @@ describe("ObanDAO Unit Tests", () => {
 
             const tradeId = "trade-uuid-456";
 
-            const mockJob = { id: BigInt(10), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(10);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeAnnouncement(tradeId);
@@ -327,7 +327,7 @@ describe("ObanDAO Unit Tests", () => {
 
             const tradeId = "trade-uuid-789";
 
-            const mockJob = { id: BigInt(11), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(11);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeAnnouncement(tradeId);
@@ -347,7 +347,7 @@ describe("ObanDAO Unit Tests", () => {
     describe("enqueueTradeRequestDm", () => {
         it("should enqueue trade_request_dm on discord queue", async () => {
             process.env.APP_ENV = "staging";
-            const mockJob = { id: BigInt(30), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(30);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeRequestDm(
@@ -376,7 +376,7 @@ describe("ObanDAO Unit Tests", () => {
 
         it("should include notification_settings_url when provided", async () => {
             process.env.APP_ENV = "staging";
-            const mockJob = { id: BigInt(33), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(33);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeRequestDm(
@@ -401,7 +401,7 @@ describe("ObanDAO Unit Tests", () => {
     describe("enqueueTradeSubmitDm", () => {
         it("should enqueue trade_submit_dm on discord queue", async () => {
             process.env.APP_ENV = "production";
-            const mockJob = { id: BigInt(31), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(31);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeSubmitDm("t2", "u2", "https://app/trades/t2?action=submit&token=c");
@@ -423,7 +423,7 @@ describe("ObanDAO Unit Tests", () => {
 
         it("should include notification_settings_url when provided", async () => {
             process.env.APP_ENV = "production";
-            const mockJob = { id: BigInt(34), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(34);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeSubmitDm(
@@ -447,7 +447,7 @@ describe("ObanDAO Unit Tests", () => {
     describe("enqueueTradeDeclinedDm", () => {
         it("should enqueue trade_declined_dm with optional decline_url", async () => {
             process.env.APP_ENV = "development";
-            const mockJob = { id: BigInt(32), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(32);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeDeclinedDm("t3", "u3", true, "https://app/trades/t3?token=v");
@@ -470,7 +470,7 @@ describe("ObanDAO Unit Tests", () => {
 
         it("should include notification_settings_url when provided", async () => {
             process.env.APP_ENV = "development";
-            const mockJob = { id: BigInt(35), state: oban_job_state.available };
+            const mockJob = ObanJobFactory.getMockJob(35);
             mockPrismaObanJob.create.mockResolvedValue(mockJob as any);
 
             await obanDao.enqueueTradeDeclinedDm(

--- a/tests/unit/DAO/v2/PlayerDAO.test.ts
+++ b/tests/unit/DAO/v2/PlayerDAO.test.ts
@@ -1,46 +1,24 @@
 import { mockDeep, mockClear } from "jest-mock-extended";
-import PlayerDAO, { PlayerWithTeam } from "../../../../src/DAO/v2/PlayerDAO";
+import PlayerDAO, { playerOwnerTeamInclude } from "../../../../src/DAO/v2/PlayerDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
-import logger from "../../../../src/bootstrap/logger";
+import { PlayerFactory } from "../../../factories/PlayerFactory";
+import { daoTestLifecycle, expectDaoRequiresPrismaClient } from "./daoTestHelpers";
 import { v4 as uuid } from "uuid";
 import { PlayerLeagueLevel } from "@prisma/client";
 
-const makePlayer = (overrides: Record<string, unknown> = {}) =>
-    ({
-        id: uuid(),
-        name: "Mike Trout",
-        league: PlayerLeagueLevel.MAJORS,
-        mlbTeam: "LAA",
-        playerDataId: 12345,
-        leagueTeamId: null,
-        meta: null,
-        dateCreated: new Date(),
-        dateModified: new Date(),
-        ownerTeam: null,
-        ...overrides,
-    } as unknown as PlayerWithTeam);
+const makePlayer = (...args: Parameters<typeof PlayerFactory.getPrismaPlayerWithTeam>) =>
+    PlayerFactory.getPrismaPlayerWithTeam(...args);
 
 describe("[PRISMA] PlayerDAO", () => {
     const prisma = mockDeep<ExtendedPrismaClient["player"]>();
     const dao = new PlayerDAO(prisma as unknown as ExtendedPrismaClient["player"]);
 
-    beforeAll(() => {
-        logger.debug("~~~~~~PRISMA PLAYER DAO TESTS BEGIN~~~~~~");
-    });
-    afterAll(() => {
-        logger.debug("~~~~~~PRISMA PLAYER DAO TESTS COMPLETE~~~~~~");
-    });
+    daoTestLifecycle("PLAYER");
     afterEach(() => {
         mockClear(prisma);
     });
 
-    describe("constructor", () => {
-        it("should throw when initialized without a prisma client", () => {
-            expect(() => new PlayerDAO(undefined)).toThrow(
-                "PlayerDAO must be initialized with a PrismaClient model instance!"
-            );
-        });
-    });
+    expectDaoRequiresPrismaClient(PlayerDAO, "PlayerDAO");
 
     describe("getAllPlayers", () => {
         it("should return all players ordered by id", async () => {
@@ -67,7 +45,7 @@ describe("[PRISMA] PlayerDAO", () => {
                     orderBy: { name: "asc" },
                     skip: 0,
                     take: 50,
-                    include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
+                    include: playerOwnerTeamInclude,
                 })
             );
             expect(prisma.count).toHaveBeenCalledWith({ where: {} });
@@ -137,7 +115,7 @@ describe("[PRISMA] PlayerDAO", () => {
 
             expect(prisma.findUniqueOrThrow).toHaveBeenCalledWith({
                 where: { id: player.id },
-                include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
+                include: playerOwnerTeamInclude,
             });
             expect(result.id).toBe(player.id);
         });
@@ -165,7 +143,7 @@ describe("[PRISMA] PlayerDAO", () => {
                     playerDataId: 999,
                     leagueTeamId: teamId,
                 },
-                include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
+                include: playerOwnerTeamInclude,
             });
         });
 
@@ -183,7 +161,7 @@ describe("[PRISMA] PlayerDAO", () => {
                     playerDataId: null,
                     leagueTeamId: null,
                 },
-                include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
+                include: playerOwnerTeamInclude,
             });
         });
     });
@@ -198,7 +176,7 @@ describe("[PRISMA] PlayerDAO", () => {
             expect(prisma.update).toHaveBeenCalledWith({
                 where: { id: player.id },
                 data: { name: "Updated Name" },
-                include: { ownerTeam: { select: { id: true, name: true, owners: { select: { csvName: true } } } } },
+                include: playerOwnerTeamInclude,
             });
             expect(result.name).toBe("Updated Name");
         });

--- a/tests/unit/DAO/v2/SyncJobExecutionDAO.test.ts
+++ b/tests/unit/DAO/v2/SyncJobExecutionDAO.test.ts
@@ -1,7 +1,7 @@
 import { mockDeep, mockClear } from "jest-mock-extended";
 import SyncJobExecutionDAO from "../../../../src/DAO/v2/SyncJobExecutionDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
-import logger from "../../../../src/bootstrap/logger";
+import { daoTestLifecycle, expectDaoRequiresPrismaClient } from "./daoTestHelpers";
 import { SyncJobType } from "@prisma/client";
 
 const makeSyncExecution = (overrides: Record<string, unknown> = {}) => ({
@@ -19,23 +19,12 @@ describe("[PRISMA] SyncJobExecutionDAO", () => {
     const prisma = mockDeep<ExtendedPrismaClient["syncJobExecution"]>();
     const dao = new SyncJobExecutionDAO(prisma as unknown as ExtendedPrismaClient["syncJobExecution"]);
 
-    beforeAll(() => {
-        logger.debug("~~~~~~PRISMA SYNC JOB EXECUTION DAO TESTS BEGIN~~~~~~");
-    });
-    afterAll(() => {
-        logger.debug("~~~~~~PRISMA SYNC JOB EXECUTION DAO TESTS COMPLETE~~~~~~");
-    });
+    daoTestLifecycle("SYNC JOB EXECUTION");
     afterEach(() => {
         mockClear(prisma);
     });
 
-    describe("constructor", () => {
-        it("should throw when initialized without a prisma client", () => {
-            expect(() => new SyncJobExecutionDAO(undefined)).toThrow(
-                "SyncJobExecutionDAO must be initialized with a PrismaClient model instance!"
-            );
-        });
-    });
+    expectDaoRequiresPrismaClient(SyncJobExecutionDAO, "SyncJobExecutionDAO");
 
     describe("getByObanJobId", () => {
         it("should find the most recent execution for a given oban job id", async () => {

--- a/tests/unit/DAO/v2/TeamDAO.test.ts
+++ b/tests/unit/DAO/v2/TeamDAO.test.ts
@@ -1,43 +1,23 @@
 import { mockDeep, mockClear } from "jest-mock-extended";
-import TeamDAO, { TeamWithOwners } from "../../../../src/DAO/v2/TeamDAO";
+import TeamDAO, { teamInclude } from "../../../../src/DAO/v2/TeamDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
-import logger from "../../../../src/bootstrap/logger";
-import { v4 as uuid } from "uuid";
+import { TeamFactory } from "../../../factories/TeamFactory";
+import { daoTestLifecycle, expectDaoRequiresPrismaClient } from "./daoTestHelpers";
 import { TeamStatus } from "@prisma/client";
 
-const makeTeam = (overrides: Record<string, unknown> = {}): TeamWithOwners =>
-    ({
-        id: uuid(),
-        name: "Test Team",
-        espnId: 1,
-        status: TeamStatus.ACTIVE,
-        dateCreated: new Date(),
-        dateModified: new Date(),
-        owners: [],
-        ...overrides,
-    } as unknown as TeamWithOwners);
+const makeTeam = (...args: Parameters<typeof TeamFactory.getPrismaTeamWithOwners>) =>
+    TeamFactory.getPrismaTeamWithOwners(...args);
 
 describe("[PRISMA] TeamDAO", () => {
     const prisma = mockDeep<ExtendedPrismaClient["team"]>();
     const dao = new TeamDAO(prisma as unknown as ExtendedPrismaClient["team"]);
 
-    beforeAll(() => {
-        logger.debug("~~~~~~PRISMA TEAM DAO TESTS BEGIN~~~~~~");
-    });
-    afterAll(() => {
-        logger.debug("~~~~~~PRISMA TEAM DAO TESTS COMPLETE~~~~~~");
-    });
+    daoTestLifecycle("TEAM");
     afterEach(() => {
         mockClear(prisma);
     });
 
-    describe("constructor", () => {
-        it("should throw when initialized without a prisma client", () => {
-            expect(() => new TeamDAO(undefined)).toThrow(
-                "TeamDAO must be initialized with a PrismaClient model instance!"
-            );
-        });
-    });
+    expectDaoRequiresPrismaClient(TeamDAO, "TeamDAO");
 
     describe("getAllTeams", () => {
         it("should return teams ordered by name with owners included", async () => {
@@ -48,11 +28,7 @@ describe("[PRISMA] TeamDAO", () => {
 
             expect(prisma.findMany).toHaveBeenCalledWith({
                 orderBy: { name: "asc" },
-                include: {
-                    owners: {
-                        select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
-                    },
-                },
+                include: teamInclude,
             });
             expect(result).toHaveLength(2);
         });
@@ -67,11 +43,7 @@ describe("[PRISMA] TeamDAO", () => {
 
             expect(prisma.findUniqueOrThrow).toHaveBeenCalledWith({
                 where: { id: team.id },
-                include: {
-                    owners: {
-                        select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
-                    },
-                },
+                include: teamInclude,
             });
             expect(result.id).toBe(team.id);
         });
@@ -86,11 +58,7 @@ describe("[PRISMA] TeamDAO", () => {
 
             expect(prisma.create).toHaveBeenCalledWith({
                 data: { name: "New Team", espnId: 5, status: TeamStatus.ACTIVE },
-                include: {
-                    owners: {
-                        select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
-                    },
-                },
+                include: teamInclude,
             });
             expect(result.name).toBe("New Team");
         });
@@ -119,11 +87,7 @@ describe("[PRISMA] TeamDAO", () => {
             expect(prisma.update).toHaveBeenCalledWith({
                 where: { id: team.id },
                 data: { name: "Updated" },
-                include: {
-                    owners: {
-                        select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
-                    },
-                },
+                include: teamInclude,
             });
             expect(result.name).toBe("Updated");
         });
@@ -151,11 +115,7 @@ describe("[PRISMA] TeamDAO", () => {
 
             expect(prisma.delete).toHaveBeenCalledWith({
                 where: { id: team.id },
-                include: {
-                    owners: {
-                        select: { id: true, displayName: true, email: true, role: true, status: true, csvName: true },
-                    },
-                },
+                include: teamInclude,
             });
             expect(result.id).toBe(team.id);
         });

--- a/tests/unit/DAO/v2/TradeDAO.test.ts
+++ b/tests/unit/DAO/v2/TradeDAO.test.ts
@@ -1,33 +1,13 @@
 import { PrismaClient, TradeItemType, TradeStatus } from "@prisma/client";
 import { mockClear, mockDeep } from "jest-mock-extended";
-import TradeDAO, {
-    AcceptedByEntry,
-    PrismaTrade,
-    buildStaffTradeWhere,
-    resolvePickIds,
-} from "../../../../src/DAO/v2/TradeDAO";
+import TradeDAO, { AcceptedByEntry, buildStaffTradeWhere, resolvePickIds } from "../../../../src/DAO/v2/TradeDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
-import logger from "../../../../src/bootstrap/logger";
+import { TradeFactory } from "../../../factories/TradeFactory";
+import { daoTestLifecycle, expectDaoRequiresPrismaClient } from "./daoTestHelpers";
 import { v4 as uuid } from "uuid";
 
-const makeMinimalTrade = (overrides: Partial<PrismaTrade> = {}): PrismaTrade =>
-    ({
-        id: uuid(),
-        dateCreated: new Date(),
-        dateModified: new Date(),
-        status: TradeStatus.REQUESTED,
-        declinedReason: null,
-        declinedById: null,
-        acceptedBy: null,
-        acceptedByDetails: null,
-        acceptedOnDate: null,
-        submittedAt: null,
-        submittedById: null,
-        tradeParticipants: [],
-        tradeItems: [],
-        emails: [],
-        ...overrides,
-    } as unknown as PrismaTrade);
+const makeMinimalTrade = (...args: Parameters<typeof TradeFactory.getPrismaTrade>) =>
+    TradeFactory.getPrismaTrade(...args);
 
 describe("[PRISMA] TradeDAO", () => {
     const prisma = mockDeep<PrismaClient["trade"]>();
@@ -35,23 +15,12 @@ describe("[PRISMA] TradeDAO", () => {
     const tradeId = uuid();
     const testTrade = makeMinimalTrade({ id: tradeId });
 
-    beforeAll(() => {
-        logger.debug("~~~~~~PRISMA TRADE DAO TESTS BEGIN~~~~~~");
-    });
-    afterAll(() => {
-        logger.debug("~~~~~~PRISMA TRADE DAO TESTS COMPLETE~~~~~~");
-    });
+    daoTestLifecycle("TRADE");
     afterEach(() => {
         mockClear(prisma);
     });
 
-    describe("constructor", () => {
-        it("should throw when initialized without a prisma client", () => {
-            expect(() => new TradeDAO(undefined)).toThrow(
-                "TradeDAO must be initialized with a PrismaClient model instance!"
-            );
-        });
-    });
+    expectDaoRequiresPrismaClient(TradeDAO, "TradeDAO");
 
     describe("getTradeById", () => {
         it("should call findUniqueOrThrow with id and relations", async () => {

--- a/tests/unit/DAO/v2/UserDAO.test.ts
+++ b/tests/unit/DAO/v2/UserDAO.test.ts
@@ -1,52 +1,21 @@
 import { mockDeep, mockClear } from "jest-mock-extended";
-import UserDAO, { PublicUser } from "../../../../src/DAO/v2/UserDAO";
+import UserDAO from "../../../../src/DAO/v2/UserDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
-import logger from "../../../../src/bootstrap/logger";
-import { v4 as uuid } from "uuid";
-import { UserRole, UserStatus } from "@prisma/client";
+import { UserFactory } from "../../../factories/UserFactory";
+import { daoTestLifecycle, expectDaoRequiresPrismaClient } from "./daoTestHelpers";
 
-const makeUser = (overrides: Record<string, unknown> = {}) => ({
-    id: uuid(),
-    email: "test@example.com",
-    displayName: "Test User",
-    password: "hashed-secret",
-    role: UserRole.OWNER,
-    status: UserStatus.ACTIVE,
-    slackUsername: null,
-    discordUserId: null,
-    teamId: null,
-    espnMember: null,
-    lastLoggedIn: null,
-    dateCreated: new Date(),
-    dateModified: new Date(),
-    passwordResetToken: null,
-    passwordResetExpiresOn: null,
-    csvName: null,
-    userSettings: null,
-    ...overrides,
-});
+const makeUser = (...args: Parameters<typeof UserFactory.getPrismaUser>) => UserFactory.getPrismaUser(...args);
 
 describe("[PRISMA] UserDAO", () => {
     const prisma = mockDeep<ExtendedPrismaClient["user"]>();
     const dao = new UserDAO(prisma as unknown as ExtendedPrismaClient["user"]);
 
-    beforeAll(() => {
-        logger.debug("~~~~~~PRISMA USER DAO TESTS BEGIN~~~~~~");
-    });
-    afterAll(() => {
-        logger.debug("~~~~~~PRISMA USER DAO TESTS COMPLETE~~~~~~");
-    });
+    daoTestLifecycle("USER");
     afterEach(() => {
         mockClear(prisma);
     });
 
-    describe("constructor", () => {
-        it("should throw when initialized without a prisma client", () => {
-            expect(() => new UserDAO(undefined)).toThrow(
-                "UserDAO must be initialized with a PrismaClient model instance!"
-            );
-        });
-    });
+    expectDaoRequiresPrismaClient(UserDAO, "UserDAO");
 
     describe("publicUser / publicUsers", () => {
         it("should strip the password field from a user", () => {

--- a/tests/unit/DAO/v2/daoTestHelpers.ts
+++ b/tests/unit/DAO/v2/daoTestHelpers.ts
@@ -1,0 +1,51 @@
+import logger from "../../../../src/bootstrap/logger";
+
+// Note: `jest/no-export` is disabled per-export below. This is a shared helper
+// module (not a test suite); its exports are consumed by the *.test.ts files here.
+
+/**
+ * Shared helpers for the v2 DAO unit tests.
+ *
+ * These are imported by the `*.test.ts` files in this directory; the jest globals
+ * (`beforeAll`/`afterAll`/`describe`/`it`/`expect`) are referenced lazily so they
+ * resolve at call time inside a test run. This file is not itself a test suite
+ * (it does not match jest's `testMatch`).
+ */
+
+/**
+ * Registers the `~~~~~~PRISMA <NAME> DAO TESTS BEGIN/COMPLETE~~~~~~` debug banners
+ * that make local test output easy to follow. Replaces the hand-written
+ * beforeAll/afterAll pair in each DAO test file.
+ *
+ * @param name Upper-case entity label, e.g. "USER", "DRAFTPICK", "SYNC JOB EXECUTION".
+ */
+// eslint-disable-next-line jest/no-export
+export function daoTestLifecycle(name: string): void {
+    beforeAll(() => {
+        logger.debug(`~~~~~~PRISMA ${name} DAO TESTS BEGIN~~~~~~`);
+    });
+    afterAll(() => {
+        logger.debug(`~~~~~~PRISMA ${name} DAO TESTS COMPLETE~~~~~~`);
+    });
+}
+
+/**
+ * Asserts a DAO throws the standard guard error when constructed without a
+ * PrismaClient model instance. Registers its own `describe`/`it` block.
+ *
+ * @param DaoClass The DAO class under test.
+ * @param daoName  The class name as it appears in the thrown error message.
+ */
+// eslint-disable-next-line jest/no-export
+export function expectDaoRequiresPrismaClient(
+    DaoClass: new (prismaModel: undefined) => unknown,
+    daoName: string
+): void {
+    describe("constructor", () => {
+        it("should throw when initialized without a prisma client", () => {
+            expect(() => new DaoClass(undefined)).toThrow(
+                `${daoName} must be initialized with a PrismaClient model instance!`
+            );
+        });
+    });
+}


### PR DESCRIPTION
## Summary

Three pieces of groundwork for the upcoming Trade Request builder, plus a docs home for the repo. No application/runtime behavior changes — additions are docs, test-only helpers/factories, and DAO query-shape refactors that keep identical output.

### 1. `docs/` structure + ADRs (`1223613`)
- Add a top-level `docs/README.md` and per-directory `README.md` indexes for progressive discovery.
- Resolve a duplicate ADR `0001` by renumbering staff-trade-search to **ADR 0002**.
- Add **ADR 0003** (Trade Request builder — v2 DAO scope, first pass) and the trade-builder API proposal it records.
- Point `AGENTS.md` at `docs/` with explicit "when to read" guidance; ignore `docs/` from eslint (it holds reference `.ts` snippets not in the build).

### 2. Shared v2 DAO test helpers & factories (`a377195`)
- New `daoTestLifecycle()` (the `PRISMA <NAME> DAO` log banners) and `expectDaoRequiresPrismaClient()` helpers; new `ObanJobFactory`.
- Add Prisma-shaped factory builders (`getPrismaTeamWithOwners`, `getPrismaPlayerWithTeam`, `getPrismaPickWithTeams`, `getPrismaTrade`) and reuse `UserFactory.getPrismaUser` instead of hand-rolling mock data in each DAO test.
- Export the owner-`include` constants from the DraftPick/Team/Player DAOs and assert against them in tests, so the expected query shape stays in sync with the DAO instead of being duplicated literally.

### 3. Prisma DAO testing guide (`2b68ef0`)
- Add `docs/testing/README.md`: unit vs. integration rules, canonical test templates, available helpers/factories, how to construct the extended Prisma client, minimum coverage per DAO, run commands (incl. docker + test-schema prereqs), and pitfalls. Linked from `AGENTS.md` and the docs index.

> Also included: `503f23a remove stale gitignore line` (pre-existing `.gitignore` tidy-up).

## Testing
- `make fullcheck` — passes (lint + format + typecheck).
- v2 DAO unit suite + the two controller tests that consume the changed factories — **129 passing**.
- Unit tests are mock-based (no DB). No integration tests were added in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
