### PR TITLE
feat: trade builder v2 DAO additions (ADR 0003)

### DIFF
--- a/src/DAO/v2/DraftPickDAO.ts
+++ b/src/DAO/v2/DraftPickDAO.ts
@@ -107,4 +107,42 @@ export default class DraftPickDAO {
             include: draftPickInclude,
         })) as unknown as DraftPickWithTeams;
     }
+
+    public async searchEligiblePicks(opts: {
+        year?: number;
+        type?: PickLeagueLevel;
+        round?: number;
+        originalOwnerId?: string;
+        currentOwnerId?: string;
+        skip?: number;
+        take?: number;
+    }): Promise<{ picks: DraftPickWithTeams[]; total: number }> {
+        const tradeableFrom = process.env.DRAFT_PICKS_TRADEABLE_FROM;
+        if (tradeableFrom) {
+            const tradeableDate = new Date(tradeableFrom);
+            if (new Date() < tradeableDate) {
+                return { picks: [], total: 0 };
+            }
+        }
+
+        const where: Prisma.DraftPickWhereInput = {};
+        if (opts.year !== undefined) where.season = opts.year;
+        if (opts.type !== undefined) where.type = opts.type;
+        if (opts.round !== undefined) where.round = new Prisma.Decimal(opts.round);
+        if (opts.originalOwnerId !== undefined) where.originalOwnerId = opts.originalOwnerId;
+        if (opts.currentOwnerId !== undefined) where.currentOwnerId = opts.currentOwnerId;
+
+        const [picks, total] = await Promise.all([
+            this.pickDb.findMany({
+                where,
+                orderBy: [{ season: "desc" }, { round: "asc" }],
+                skip: opts.skip ?? 0,
+                take: opts.take ?? 50,
+                include: draftPickInclude,
+            }),
+            this.pickDb.count({ where }),
+        ]);
+
+        return { picks: picks as unknown as DraftPickWithTeams[], total };
+    }
 }

--- a/src/DAO/v2/PlayerDAO.ts
+++ b/src/DAO/v2/PlayerDAO.ts
@@ -30,6 +30,7 @@ export default class PlayerDAO {
     public async searchPlayers(opts?: {
         search?: string;
         league?: PlayerLeagueLevel;
+        ownerTeamIds?: string[];
         skip?: number;
         take?: number;
     }): Promise<{ players: PlayerWithTeam[]; total: number }> {
@@ -37,6 +38,9 @@ export default class PlayerDAO {
         if (opts?.league) where.league = opts.league;
         if (opts?.search) {
             where.name = { contains: opts.search, mode: "insensitive" };
+        }
+        if (opts?.ownerTeamIds && opts.ownerTeamIds.length > 0) {
+            where.leagueTeamId = { in: opts.ownerTeamIds };
         }
 
         const [players, total] = await Promise.all([

--- a/src/DAO/v2/TeamDAO.ts
+++ b/src/DAO/v2/TeamDAO.ts
@@ -70,4 +70,23 @@ export default class TeamDAO {
             include: teamInclude,
         })) as unknown as TeamWithOwners;
     }
+
+    public async searchTeams(opts: { q: string; excludeTeamIds?: string[] }): Promise<TeamWithOwners[]> {
+        const where: Prisma.TeamWhereInput = {
+            OR: [
+                { name: { contains: opts.q, mode: "insensitive" } },
+                { owners: { some: { csvName: { contains: opts.q, mode: "insensitive" } } } },
+            ],
+        };
+
+        if (opts.excludeTeamIds && opts.excludeTeamIds.length > 0) {
+            where.id = { notIn: opts.excludeTeamIds };
+        }
+
+        return (await this.teamDb.findMany({
+            where,
+            orderBy: { name: "asc" },
+            include: teamInclude,
+        })) as unknown as TeamWithOwners[];
+    }
 }

--- a/src/DAO/v2/TradeDAO.ts
+++ b/src/DAO/v2/TradeDAO.ts
@@ -1,4 +1,4 @@
-import { Prisma, TradeItemType, TradeStatus } from "@prisma/client";
+import { Prisma, TradeItemType, TradeParticipantType, TradeStatus } from "@prisma/client";
 import { ExtendedPrismaClient } from "../../bootstrap/prisma-db";
 
 export interface AcceptedByEntry {
@@ -42,7 +42,7 @@ export interface TeamTradeFilters {
 }
 
 /** The Prisma include shape used consistently across all DAO methods */
-const tradeWithRelations = {
+export const tradeWithRelations = {
     tradeParticipants: {
         include: {
             team: {
@@ -237,6 +237,214 @@ export default class TradeDAO {
             },
         });
         return this.getTradeById(id);
+    }
+
+    // ─── Write methods ──────────────────────────────────────────────────────────
+
+    /**
+     * Creates a new DRAFT trade with a CREATOR participant and one or more RECIPIENT participants.
+     * Returns the fully hydrated trade.
+     */
+    public async createDraft({
+        creatorTeamId,
+        participantTeamIds,
+    }: {
+        creatorTeamId: string;
+        participantTeamIds: string[];
+    }): Promise<PrismaTrade> {
+        const result = await this.tradeDb.create({
+            data: {
+                status: TradeStatus.DRAFT,
+                tradeParticipants: {
+                    create: [
+                        { participantType: TradeParticipantType.CREATOR, teamId: creatorTeamId },
+                        ...participantTeamIds.map(id => ({
+                            participantType: TradeParticipantType.RECIPIENT,
+                            teamId: id,
+                        })),
+                    ],
+                },
+            },
+        });
+        return this.getTradeById(result.id);
+    }
+
+    /**
+     * Replaces all RECIPIENT participants on a trade with the given teamIds.
+     * The CREATOR participant is left untouched.
+     * Returns the fully hydrated trade.
+     */
+    public async updateDraftParticipants(tradeId: string, participantTeamIds: string[]): Promise<PrismaTrade> {
+        await this.tradeDb.update({
+            where: { id: tradeId },
+            data: {
+                tradeParticipants: {
+                    deleteMany: { participantType: TradeParticipantType.RECIPIENT },
+                    create: participantTeamIds.map(id => ({
+                        participantType: TradeParticipantType.RECIPIENT,
+                        teamId: id,
+                    })),
+                },
+            },
+        });
+        return this.getTradeById(tradeId);
+    }
+
+    /**
+     * Adds a trade item (player or pick) to an existing trade.
+     * The @@unique constraint on TradeItem dedupes identical items.
+     * Returns the fully hydrated trade.
+     */
+    public async addTradeItem(
+        tradeId: string,
+        {
+            tradeItemType,
+            tradeItemId,
+            senderId,
+            recipientId,
+        }: {
+            tradeItemType: TradeItemType;
+            tradeItemId: string;
+            senderId: string;
+            recipientId: string;
+        }
+    ): Promise<PrismaTrade> {
+        await this.tradeDb.update({
+            where: { id: tradeId },
+            data: {
+                tradeItems: {
+                    create: { tradeItemType, tradeItemId, senderId, recipientId },
+                },
+            },
+        });
+        return this.getTradeById(tradeId);
+    }
+
+    /**
+     * Updates senderId and/or recipientId on a specific TradeItem (identified by lineId).
+     * Uses the provided tradeItemDb delegate to perform the update and resolve the parent tradeId.
+     * Returns the fully hydrated parent trade.
+     */
+    public async updateTradeItem(
+        lineId: string,
+        updates: { senderId?: string; recipientId?: string },
+        tradeItemDb: ExtendedPrismaClient["tradeItem"]
+    ): Promise<PrismaTrade> {
+        const updated = await tradeItemDb.update({
+            where: { id: lineId },
+            data: updates,
+            select: { tradeId: true },
+        });
+        if (!updated.tradeId) {
+            throw new Error(`updateTradeItem: TradeItem ${lineId} has no associated tradeId`);
+        }
+        return this.getTradeById(updated.tradeId);
+    }
+
+    /**
+     * Deletes a specific TradeItem (identified by lineId) from its parent trade.
+     * Uses the provided tradeItemDb delegate to find and delete the item.
+     * Returns the fully hydrated parent trade.
+     */
+    public async removeTradeItem(lineId: string, tradeItemDb: ExtendedPrismaClient["tradeItem"]): Promise<PrismaTrade> {
+        const item = await tradeItemDb.findUniqueOrThrow({
+            where: { id: lineId },
+            select: { tradeId: true },
+        });
+        if (!item.tradeId) {
+            throw new Error(`removeTradeItem: TradeItem ${lineId} has no associated tradeId`);
+        }
+        await tradeItemDb.delete({ where: { id: lineId } });
+        return this.getTradeById(item.tradeId);
+    }
+
+    /**
+     * Deletes a DRAFT trade, guarded by authz checks:
+     * - The trade must be in DRAFT status.
+     * - requestingUserId must be an owner of the CREATOR team.
+     * Throws descriptive errors if either check fails.
+     */
+    public async deleteDraft(tradeId: string, requestingUserId: string): Promise<void> {
+        const trade = await this.getTradeById(tradeId);
+
+        if (trade.status !== TradeStatus.DRAFT) {
+            throw new Error(`deleteDraft: trade ${tradeId} is not in DRAFT status (current: ${trade.status})`);
+        }
+
+        const creatorParticipant = trade.tradeParticipants.find(
+            p => p.participantType === TradeParticipantType.CREATOR
+        );
+        if (!creatorParticipant?.team) {
+            throw new Error(`deleteDraft: trade ${tradeId} has no CREATOR participant with a team`);
+        }
+
+        const isOwner = creatorParticipant.team.owners.some(owner => owner.id === requestingUserId);
+        if (!isOwner) {
+            throw new Error(
+                `Unauthorized: user ${requestingUserId} is not an owner of the CREATOR team for trade ${tradeId}`
+            );
+        }
+
+        await this.tradeDb.delete({ where: { id: tradeId } });
+    }
+
+    /**
+     * Lists DRAFT trades where any of the given teamIds is a participant.
+     * Supports pagination and sort order.
+     * Returns matching trades and total count.
+     */
+    public async listDraftsForUser({
+        teamIds,
+        skip,
+        take,
+        sort,
+    }: {
+        teamIds: string[];
+        skip: number;
+        take: number;
+        sort?: TeamTradeOrderBy;
+    }): Promise<{ trades: PrismaTrade[]; total: number }> {
+        const where: Prisma.TradeWhereInput = {
+            status: TradeStatus.DRAFT,
+            tradeParticipants: {
+                some: { teamId: { in: teamIds } },
+            },
+        };
+
+        const orderByClause: Prisma.TradeOrderByWithRelationInput =
+            sort === "SUBMITTED" ? { submittedAt: "desc" } : { dateCreated: "desc" };
+
+        const [trades, total] = await Promise.all([
+            this.tradeDb.findMany({
+                where,
+                include: tradeWithRelations,
+                orderBy: orderByClause,
+                skip,
+                take,
+            }),
+            this.tradeDb.count({ where }),
+        ]);
+
+        return { trades, total };
+    }
+
+    /**
+     * Transitions a trade from DRAFT to REQUESTED status.
+     * Throws if the trade is not currently in DRAFT status.
+     * Returns the fully hydrated trade. Notification enqueueing is the caller's responsibility.
+     */
+    public async requestTrade(tradeId: string): Promise<PrismaTrade> {
+        const trade = await this.getTradeById(tradeId);
+
+        if (trade.status !== TradeStatus.DRAFT) {
+            throw new Error(`requestTrade: trade ${tradeId} is not in DRAFT status (current: ${trade.status})`);
+        }
+
+        await this.tradeDb.update({
+            where: { id: tradeId },
+            data: { status: TradeStatus.REQUESTED },
+        });
+        return this.getTradeById(tradeId);
     }
 }
 

--- a/src/services/tradeBuilder/notificationPrefs.ts
+++ b/src/services/tradeBuilder/notificationPrefs.ts
@@ -1,0 +1,36 @@
+import { ExtendedPrismaClient } from "../../bootstrap/prisma-db";
+import { normalizeUserSettings } from "../../utils/userSettings";
+
+export interface NotificationChannels {
+    email: boolean;
+    discordDm: boolean;
+    discordUserId: string | null;
+}
+
+/**
+ * Resolves notification channel preferences for a single user.
+ * Accepts a Prisma user delegate so callers can pass their existing db handle
+ * without needing a full PrismaClient instance.
+ */
+export async function willNotifyVia(
+    userId: string,
+    userDb: ExtendedPrismaClient["user"]
+): Promise<NotificationChannels> {
+    const row = await userDb.findUnique({
+        where: { id: userId },
+        select: { id: true, discordUserId: true, userSettings: true },
+    });
+
+    if (!row) {
+        return { email: false, discordDm: false, discordUserId: null };
+    }
+
+    const normalized = normalizeUserSettings(row.userSettings);
+    const trimmedDiscord = row.discordUserId?.trim() || null;
+
+    return {
+        email: normalized.notifications.tradeActionEmail,
+        discordDm: !!trimmedDiscord && normalized.notifications.tradeActionDiscordDm,
+        discordUserId: trimmedDiscord,
+    };
+}

--- a/src/services/tradeBuilder/tradeValidator.ts
+++ b/src/services/tradeBuilder/tradeValidator.ts
@@ -1,0 +1,114 @@
+import { TradeParticipantType } from "@prisma/client";
+import TradeDAO, { PrismaTrade } from "../../DAO/v2/TradeDAO";
+
+export interface TeamSummary {
+    teamId: string;
+    teamName: string;
+    sendsCount: number;
+    receivesCount: number;
+}
+
+export interface TradeSummary {
+    trade: PrismaTrade;
+    teams: TeamSummary[]; // one entry per participant team
+}
+
+export type ValidationErrorCode = "MISSING_CREATOR" | "MULTIPLE_CREATORS" | "NO_RECIPIENTS" | "NO_TRADE_ITEMS";
+
+export type ValidationWarningCode = "TEAM_RECEIVES_NOTHING";
+
+export interface ValidationError {
+    code: ValidationErrorCode;
+    message: string;
+}
+
+export interface ValidationWarning {
+    code: ValidationWarningCode;
+    message: string;
+    teamId?: string;
+    teamName?: string;
+}
+
+export interface TradeValidationResult {
+    summary: TradeSummary;
+    errors: ValidationError[];
+    warnings: ValidationWarning[];
+    canSend: boolean; // errors.length === 0
+}
+
+/**
+ * Hydrates the trade and computes per-team send/receive counts.
+ * This is the single source of truth for item counts — both validateTrade
+ * and the /review endpoint should call this rather than re-computing counts.
+ */
+export async function buildTradeSummary(tradeId: string, tradeDao: TradeDAO): Promise<TradeSummary> {
+    const trade = await tradeDao.getTradeById(tradeId);
+
+    const teams: TeamSummary[] = trade.tradeParticipants
+        .filter((p): p is typeof p & { teamId: string } => p.teamId !== null)
+        .map(p => {
+            const teamId = p.teamId;
+            const sendsCount = trade.tradeItems.filter(item => item.senderId === teamId).length;
+            const receivesCount = trade.tradeItems.filter(item => item.recipientId === teamId).length;
+
+            return {
+                teamId,
+                teamName: p.team?.name ?? teamId,
+                sendsCount,
+                receivesCount,
+            };
+        });
+
+    return { trade, teams };
+}
+
+/**
+ * Validates a trade's structural integrity.
+ * Returns errors (blocking) and warnings (advisory) derived from the trade summary.
+ */
+export async function validateTrade(tradeId: string, tradeDao: TradeDAO): Promise<TradeValidationResult> {
+    const summary = await buildTradeSummary(tradeId, tradeDao);
+    const { trade, teams } = summary;
+
+    const errors: ValidationError[] = [];
+    const warnings: ValidationWarning[] = [];
+
+    // Structural checks
+    const creators = trade.tradeParticipants.filter(p => p.participantType === TradeParticipantType.CREATOR);
+    const recipients = trade.tradeParticipants.filter(p => p.participantType === TradeParticipantType.RECIPIENT);
+
+    if (creators.length === 0) {
+        errors.push({ code: "MISSING_CREATOR", message: "Trade must have exactly one creator." });
+    }
+
+    if (creators.length > 1) {
+        errors.push({ code: "MULTIPLE_CREATORS", message: "Trade cannot have more than one creator." });
+    }
+
+    if (recipients.length === 0) {
+        errors.push({ code: "NO_RECIPIENTS", message: "Trade must have at least one recipient." });
+    }
+
+    if (trade.tradeItems.length === 0) {
+        errors.push({ code: "NO_TRADE_ITEMS", message: "Trade must include at least one item." });
+    }
+
+    // Advisory warnings
+    for (const team of teams) {
+        if (team.receivesCount === 0) {
+            warnings.push({
+                code: "TEAM_RECEIVES_NOTHING",
+                message: `Team "${team.teamName}" receives nothing in this trade.`,
+                teamId: team.teamId,
+                teamName: team.teamName,
+            });
+        }
+    }
+
+    return {
+        summary,
+        errors,
+        warnings,
+        canSend: errors.length === 0,
+    };
+}

--- a/tests/integration/v2/db/DraftPickDAO.integration.test.ts
+++ b/tests/integration/v2/db/DraftPickDAO.integration.test.ts
@@ -1,0 +1,121 @@
+import { Prisma, PickLeagueLevel } from "@prisma/client";
+import { clearPrismaDb } from "../../helpers";
+import initializeDb, { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
+import DraftPickDAO from "../../../../src/DAO/v2/DraftPickDAO";
+
+let prisma: ExtendedPrismaClient;
+let pickDao: DraftPickDAO;
+
+beforeAll(() => {
+    prisma = initializeDb(process.env.DB_LOGS === "true");
+    pickDao = new DraftPickDAO(prisma.draftPick);
+});
+
+afterAll(async () => {
+    await prisma.$disconnect();
+});
+
+afterEach(async () => {
+    await clearPrismaDb(prisma);
+});
+
+describe("integration/ DraftPickDAO.searchEligiblePicks", () => {
+    it("integration/ filters by year (season)", async () => {
+        await prisma.draftPick.create({
+            data: { round: new Prisma.Decimal(1), season: 2026, type: PickLeagueLevel.MAJORS },
+        });
+        await prisma.draftPick.create({
+            data: { round: new Prisma.Decimal(1), season: 2027, type: PickLeagueLevel.MAJORS },
+        });
+
+        const { picks, total } = await pickDao.searchEligiblePicks({ year: 2026 });
+
+        expect(total).toBe(1);
+        expect(picks).toHaveLength(1);
+        expect(picks[0].season).toBe(2026);
+    });
+
+    it("integration/ filters by year + type + round together", async () => {
+        await prisma.draftPick.create({
+            data: { round: new Prisma.Decimal(1), season: 2026, type: PickLeagueLevel.MAJORS }, // match
+        });
+        await prisma.draftPick.create({
+            data: { round: new Prisma.Decimal(1), season: 2026, type: PickLeagueLevel.LOWMINORS }, // wrong type
+        });
+        await prisma.draftPick.create({
+            data: { round: new Prisma.Decimal(2), season: 2026, type: PickLeagueLevel.MAJORS }, // wrong round
+        });
+
+        const { picks, total } = await pickDao.searchEligiblePicks({
+            year: 2026,
+            type: PickLeagueLevel.MAJORS,
+            round: 1,
+        });
+
+        expect(total).toBe(1);
+        expect(picks).toHaveLength(1);
+        expect(picks[0].season).toBe(2026);
+        expect(picks[0].type).toBe("MAJORS");
+        expect(Number(picks[0].round)).toBe(1);
+    });
+
+    it("integration/ filters by currentOwnerId", async () => {
+        const team1 = await prisma.team.create({ data: { name: "Pick Owner 1", status: "ACTIVE" } });
+        const team2 = await prisma.team.create({ data: { name: "Pick Owner 2", status: "ACTIVE" } });
+
+        await prisma.draftPick.create({
+            data: {
+                round: new Prisma.Decimal(1),
+                season: 2026,
+                type: PickLeagueLevel.MAJORS,
+                currentOwnerId: team1.id,
+            },
+        });
+        await prisma.draftPick.create({
+            data: {
+                round: new Prisma.Decimal(1),
+                season: 2026,
+                type: PickLeagueLevel.MAJORS,
+                currentOwnerId: team2.id,
+            },
+        });
+
+        const { picks, total } = await pickDao.searchEligiblePicks({ currentOwnerId: team1.id });
+
+        expect(total).toBe(1);
+        expect(picks[0].currentOwnerId).toBe(team1.id);
+    });
+
+    it("integration/ returns empty result when no picks match", async () => {
+        await prisma.draftPick.create({
+            data: { round: new Prisma.Decimal(1), season: 2026, type: PickLeagueLevel.MAJORS },
+        });
+
+        const { picks, total } = await pickDao.searchEligiblePicks({ year: 2099 });
+
+        expect(total).toBe(0);
+        expect(picks).toHaveLength(0);
+    });
+
+    it("integration/ paginates correctly", async () => {
+        for (let i = 1; i <= 5; i++) {
+            await prisma.draftPick.create({
+                data: { round: new Prisma.Decimal(i), season: 2026, type: PickLeagueLevel.MAJORS },
+            });
+        }
+
+        const page1 = await pickDao.searchEligiblePicks({ year: 2026, skip: 0, take: 2 });
+        expect(page1.total).toBe(5);
+        expect(page1.picks).toHaveLength(2);
+
+        const page2 = await pickDao.searchEligiblePicks({ year: 2026, skip: 2, take: 2 });
+        expect(page2.total).toBe(5);
+        expect(page2.picks).toHaveLength(2);
+
+        // Pages should not overlap
+        const page1Ids = page1.picks.map(p => p.id);
+        const page2Ids = page2.picks.map(p => p.id);
+        const overlap = page1Ids.filter(id => page2Ids.includes(id));
+        expect(overlap).toHaveLength(0);
+    });
+});

--- a/tests/integration/v2/db/TeamDAO.integration.test.ts
+++ b/tests/integration/v2/db/TeamDAO.integration.test.ts
@@ -1,0 +1,75 @@
+import { clearPrismaDb } from "../../helpers";
+import initializeDb, { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
+import TeamDAO from "../../../../src/DAO/v2/TeamDAO";
+
+let prisma: ExtendedPrismaClient;
+let teamDao: TeamDAO;
+
+beforeAll(() => {
+    prisma = initializeDb(process.env.DB_LOGS === "true");
+    teamDao = new TeamDAO(prisma.team);
+});
+
+afterAll(async () => {
+    await prisma.$disconnect();
+});
+
+afterEach(async () => {
+    await clearPrismaDb(prisma);
+});
+
+describe("integration/ TeamDAO.searchTeams", () => {
+    it("integration/ returns teams matching by name (case-insensitive)", async () => {
+        await prisma.team.create({ data: { name: "Alpha Wolves", status: "ACTIVE" } });
+        await prisma.team.create({ data: { name: "Beta Bears", status: "ACTIVE" } });
+
+        const results = await teamDao.searchTeams({ q: "Alpha" });
+
+        expect(results).toHaveLength(1);
+        expect(results[0].name).toBe("Alpha Wolves");
+    });
+
+    it("integration/ returns teams matching by owner csvName", async () => {
+        const team = await prisma.team.create({ data: { name: "Zeta FC", status: "ACTIVE" } });
+        await prisma.user.create({
+            data: { email: "zetaowner@test.com", role: "OWNER", teamId: team.id, csvName: "ZFC" },
+        });
+        // Another team with no owner csvName match
+        await prisma.team.create({ data: { name: "Other Team", status: "ACTIVE" } });
+
+        const results = await teamDao.searchTeams({ q: "ZFC" });
+
+        expect(results).toHaveLength(1);
+        expect(results[0].name).toBe("Zeta FC");
+    });
+
+    it("integration/ excludeTeamIds excludes specified team from results", async () => {
+        const teamA = await prisma.team.create({ data: { name: "Team Alpha", status: "ACTIVE" } });
+        const teamB = await prisma.team.create({ data: { name: "Team Beta", status: "ACTIVE" } });
+        const teamC = await prisma.team.create({ data: { name: "Team Charlie", status: "ACTIVE" } });
+
+        const results = await teamDao.searchTeams({ q: "Team", excludeTeamIds: [teamB.id] });
+
+        const resultIds = results.map(t => t.id);
+        expect(resultIds).toContain(teamA.id);
+        expect(resultIds).not.toContain(teamB.id);
+        expect(resultIds).toContain(teamC.id);
+    });
+
+    it("integration/ OR logic matches by name OR owner csvName", async () => {
+        // Team matched by name
+        await prisma.team.create({ data: { name: "CSV123 Name", status: "ACTIVE" } });
+        // Team matched by owner csvName
+        const teamCsv = await prisma.team.create({ data: { name: "Csv Match", status: "ACTIVE" } });
+        await prisma.user.create({
+            data: { email: "csvowner@test.com", role: "OWNER", teamId: teamCsv.id, csvName: "CSV123" },
+        });
+
+        const results = await teamDao.searchTeams({ q: "CSV123" });
+
+        expect(results).toHaveLength(2);
+        const names = results.map(t => t.name);
+        expect(names).toContain("CSV123 Name");
+        expect(names).toContain("Csv Match");
+    });
+});

--- a/tests/integration/v2/db/TradeDAO.integration.test.ts
+++ b/tests/integration/v2/db/TradeDAO.integration.test.ts
@@ -1,0 +1,156 @@
+import { TradeItemType, TradeParticipantType, TradeStatus } from "@prisma/client";
+import { clearPrismaDb } from "../../helpers";
+import initializeDb, { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
+import TradeDAO from "../../../../src/DAO/v2/TradeDAO";
+import { v4 as uuid } from "uuid";
+
+let prisma: ExtendedPrismaClient;
+let tradeDao: TradeDAO;
+
+beforeAll(() => {
+    prisma = initializeDb(process.env.DB_LOGS === "true");
+    tradeDao = new TradeDAO(prisma.trade);
+});
+
+afterAll(async () => {
+    await prisma.$disconnect();
+});
+
+afterEach(async () => {
+    await clearPrismaDb(prisma);
+});
+
+/** Creates a team and a user that owns it. Returns both. */
+async function createTeamWithOwner(
+    teamName: string,
+    ownerEmail: string
+): Promise<{ team: { id: string }; user: { id: string } }> {
+    const team = await prisma.team.create({ data: { name: teamName, status: "ACTIVE" } });
+    const user = await prisma.user.create({
+        data: { email: ownerEmail, role: "OWNER", teamId: team.id },
+    });
+    return { team, user };
+}
+
+describe("integration/ TradeDAO write methods", () => {
+    it("integration/ createDraft → addTradeItem → requestTrade round-trip", async () => {
+        const { team: team1 } = await createTeamWithOwner("Team Alpha", "alpha@test.com");
+        const { team: team2 } = await createTeamWithOwner("Team Beta", "beta@test.com");
+
+        // createDraft
+        const draft = await tradeDao.createDraft({
+            creatorTeamId: team1.id,
+            participantTeamIds: [team2.id],
+        });
+
+        expect(draft.status).toBe(TradeStatus.DRAFT);
+        expect(draft.tradeParticipants).toHaveLength(2);
+        const creatorParticipant = draft.tradeParticipants.find(
+            p => p.participantType === TradeParticipantType.CREATOR
+        );
+        const recipientParticipant = draft.tradeParticipants.find(
+            p => p.participantType === TradeParticipantType.RECIPIENT
+        );
+        expect(creatorParticipant?.teamId).toBe(team1.id);
+        expect(recipientParticipant?.teamId).toBe(team2.id);
+
+        // addTradeItem
+        const itemId = uuid();
+        const tradeWithItem = await tradeDao.addTradeItem(draft.id, {
+            tradeItemType: TradeItemType.PLAYER,
+            tradeItemId: itemId,
+            senderId: team1.id,
+            recipientId: team2.id,
+        });
+
+        expect(tradeWithItem.tradeItems).toHaveLength(1);
+        expect(tradeWithItem.tradeItems[0].senderId).toBe(team1.id);
+        expect(tradeWithItem.tradeItems[0].recipientId).toBe(team2.id);
+
+        // requestTrade
+        const requested = await tradeDao.requestTrade(draft.id);
+        expect(requested.status).toBe(TradeStatus.REQUESTED);
+    });
+
+    it("integration/ addTradeItem dedup constraint throws on duplicate item", async () => {
+        const { team: team1 } = await createTeamWithOwner("Team Gamma", "gamma@test.com");
+        const { team: team2 } = await createTeamWithOwner("Team Delta", "delta@test.com");
+
+        const draft = await tradeDao.createDraft({
+            creatorTeamId: team1.id,
+            participantTeamIds: [team2.id],
+        });
+
+        const itemId = uuid();
+        await tradeDao.addTradeItem(draft.id, {
+            tradeItemType: TradeItemType.PLAYER,
+            tradeItemId: itemId,
+            senderId: team1.id,
+            recipientId: team2.id,
+        });
+
+        // Adding the exact same item should throw due to @@unique constraint
+        await expect(
+            tradeDao.addTradeItem(draft.id, {
+                tradeItemType: TradeItemType.PLAYER,
+                tradeItemId: itemId,
+                senderId: team1.id,
+                recipientId: team2.id,
+            })
+        ).rejects.toThrow();
+
+        // Verify only 1 item persisted
+        const trade = await tradeDao.getTradeById(draft.id);
+        expect(trade.tradeItems).toHaveLength(1);
+    });
+
+    it("integration/ deleteDraft rejects when caller does not own the CREATOR team", async () => {
+        const { team: team1 } = await createTeamWithOwner("Team Epsilon", "epsilon@test.com");
+        const { team: team2 } = await createTeamWithOwner("Team Zeta", "zeta@test.com");
+
+        // user2 is the owner of team2, NOT team1
+        const user2 = await prisma.user.findFirst({ where: { teamId: team2.id } });
+        expect(user2).not.toBeNull();
+
+        const draft = await tradeDao.createDraft({
+            creatorTeamId: team1.id,
+            participantTeamIds: [team2.id],
+        });
+
+        await expect(tradeDao.deleteDraft(draft.id, user2!.id)).rejects.toThrow(/Unauthorized/);
+
+        // Trade still exists
+        const stillExists = await prisma.trade.findUnique({ where: { id: draft.id } });
+        expect(stillExists).not.toBeNull();
+    });
+
+    it("integration/ deleteDraft rejects when trade status is not DRAFT", async () => {
+        const { team: team1, user: user1 } = await createTeamWithOwner("Team Eta", "eta@test.com");
+        const { team: team2 } = await createTeamWithOwner("Team Theta", "theta@test.com");
+
+        const draft = await tradeDao.createDraft({
+            creatorTeamId: team1.id,
+            participantTeamIds: [team2.id],
+        });
+
+        // Transition to REQUESTED
+        await tradeDao.requestTrade(draft.id);
+
+        await expect(tradeDao.deleteDraft(draft.id, user1.id)).rejects.toThrow(/not in DRAFT status/);
+    });
+
+    it("integration/ deleteDraft happy path removes the trade", async () => {
+        const { team: team1, user: user1 } = await createTeamWithOwner("Team Iota", "iota@test.com");
+        const { team: team2 } = await createTeamWithOwner("Team Kappa", "kappa@test.com");
+
+        const draft = await tradeDao.createDraft({
+            creatorTeamId: team1.id,
+            participantTeamIds: [team2.id],
+        });
+
+        await tradeDao.deleteDraft(draft.id, user1.id);
+
+        const deleted = await prisma.trade.findUnique({ where: { id: draft.id } });
+        expect(deleted).toBeNull();
+    });
+});

--- a/tests/integration/v2/db/TradeValidator.integration.test.ts
+++ b/tests/integration/v2/db/TradeValidator.integration.test.ts
@@ -1,0 +1,169 @@
+import { TradeItemType, TradeParticipantType } from "@prisma/client";
+import { clearPrismaDb } from "../../helpers";
+import initializeDb, { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
+import TradeDAO from "../../../../src/DAO/v2/TradeDAO";
+import { buildTradeSummary, validateTrade } from "../../../../src/services/tradeBuilder/tradeValidator";
+import { v4 as uuid } from "uuid";
+
+let prisma: ExtendedPrismaClient;
+let tradeDao: TradeDAO;
+
+beforeAll(() => {
+    prisma = initializeDb(process.env.DB_LOGS === "true");
+    tradeDao = new TradeDAO(prisma.trade);
+});
+
+afterAll(async () => {
+    await prisma.$disconnect();
+});
+
+afterEach(async () => {
+    await clearPrismaDb(prisma);
+});
+
+/** Creates a bare trade with specified participants and items directly via Prisma. */
+async function createRawTrade({
+    participants,
+    items = [],
+}: {
+    participants: { participantType: TradeParticipantType; teamId: string }[];
+    items?: {
+        tradeItemType: TradeItemType;
+        tradeItemId: string;
+        senderId: string;
+        recipientId: string;
+    }[];
+}): Promise<{ id: string }> {
+    return prisma.trade.create({
+        data: {
+            status: "DRAFT",
+            tradeParticipants: {
+                create: participants.map(p => ({
+                    participantType: p.participantType,
+                    teamId: p.teamId,
+                })),
+            },
+            tradeItems: {
+                create: items.map(item => ({
+                    tradeItemType: item.tradeItemType,
+                    tradeItemId: item.tradeItemId,
+                    senderId: item.senderId,
+                    recipientId: item.recipientId,
+                })),
+            },
+        },
+    });
+}
+
+describe("integration/ buildTradeSummary", () => {
+    it("integration/ computes correct send/receive counts per team", async () => {
+        const team1 = await prisma.team.create({ data: { name: "Summary Team 1", status: "ACTIVE" } });
+        const team2 = await prisma.team.create({ data: { name: "Summary Team 2", status: "ACTIVE" } });
+
+        const trade = await createRawTrade({
+            participants: [
+                { participantType: TradeParticipantType.CREATOR, teamId: team1.id },
+                { participantType: TradeParticipantType.RECIPIENT, teamId: team2.id },
+            ],
+            items: [
+                {
+                    tradeItemType: TradeItemType.PLAYER,
+                    tradeItemId: uuid(),
+                    senderId: team1.id,
+                    recipientId: team2.id,
+                },
+                {
+                    tradeItemType: TradeItemType.PLAYER,
+                    tradeItemId: uuid(),
+                    senderId: team2.id,
+                    recipientId: team1.id,
+                },
+            ],
+        });
+
+        const summary = await buildTradeSummary(trade.id, tradeDao);
+
+        const team1Summary = summary.teams.find(t => t.teamId === team1.id);
+        const team2Summary = summary.teams.find(t => t.teamId === team2.id);
+
+        expect(team1Summary?.sendsCount).toBe(1);
+        expect(team1Summary?.receivesCount).toBe(1);
+        expect(team2Summary?.sendsCount).toBe(1);
+        expect(team2Summary?.receivesCount).toBe(1);
+    });
+});
+
+describe("integration/ validateTrade", () => {
+    it("integration/ valid trade (1 creator, 1 recipient, 1 item) has no errors", async () => {
+        const team1 = await prisma.team.create({ data: { name: "Valid Team 1", status: "ACTIVE" } });
+        const team2 = await prisma.team.create({ data: { name: "Valid Team 2", status: "ACTIVE" } });
+
+        const trade = await createRawTrade({
+            participants: [
+                { participantType: TradeParticipantType.CREATOR, teamId: team1.id },
+                { participantType: TradeParticipantType.RECIPIENT, teamId: team2.id },
+            ],
+            items: [
+                {
+                    tradeItemType: TradeItemType.PLAYER,
+                    tradeItemId: uuid(),
+                    senderId: team1.id,
+                    recipientId: team2.id,
+                },
+            ],
+        });
+
+        const result = await validateTrade(trade.id, tradeDao);
+
+        expect(result.canSend).toBe(true);
+        expect(result.errors).toHaveLength(0);
+    });
+
+    it("integration/ trade with no items has NO_TRADE_ITEMS error and canSend=false", async () => {
+        const team1 = await prisma.team.create({ data: { name: "No Items Team 1", status: "ACTIVE" } });
+        const team2 = await prisma.team.create({ data: { name: "No Items Team 2", status: "ACTIVE" } });
+
+        const trade = await createRawTrade({
+            participants: [
+                { participantType: TradeParticipantType.CREATOR, teamId: team1.id },
+                { participantType: TradeParticipantType.RECIPIENT, teamId: team2.id },
+            ],
+        });
+
+        const result = await validateTrade(trade.id, tradeDao);
+
+        expect(result.canSend).toBe(false);
+        const errorCodes = result.errors.map(e => e.code);
+        expect(errorCodes).toContain("NO_TRADE_ITEMS");
+    });
+
+    it("integration/ team that receives nothing gets TEAM_RECEIVES_NOTHING warning", async () => {
+        const team1 = await prisma.team.create({ data: { name: "Sends Only Team 1", status: "ACTIVE" } });
+        const team2 = await prisma.team.create({ data: { name: "Receives Nothing Team 2", status: "ACTIVE" } });
+
+        // Item sends from team1 to team1 — team2 receives nothing
+        const trade = await createRawTrade({
+            participants: [
+                { participantType: TradeParticipantType.CREATOR, teamId: team1.id },
+                { participantType: TradeParticipantType.RECIPIENT, teamId: team2.id },
+            ],
+            items: [
+                {
+                    tradeItemType: TradeItemType.PLAYER,
+                    tradeItemId: uuid(),
+                    senderId: team1.id,
+                    recipientId: team1.id, // team2 gets nothing
+                },
+            ],
+        });
+
+        const result = await validateTrade(trade.id, tradeDao);
+
+        // Warning, not error — canSend is still true (no structural errors)
+        expect(result.canSend).toBe(true);
+        const warningCodes = result.warnings.map(w => w.code);
+        expect(warningCodes).toContain("TEAM_RECEIVES_NOTHING");
+        const team2Warning = result.warnings.find(w => w.teamId === team2.id);
+        expect(team2Warning).toBeDefined();
+    });
+});

--- a/tests/unit/DAO/v2/DraftPickDAO.test.ts
+++ b/tests/unit/DAO/v2/DraftPickDAO.test.ts
@@ -249,4 +249,139 @@ describe("[PRISMA] DraftPickDAO", () => {
             expect(result.id).toBe(pick.id);
         });
     });
+
+    describe("searchEligiblePicks", () => {
+        let savedEnvVar: string | undefined;
+
+        beforeEach(() => {
+            savedEnvVar = process.env.DRAFT_PICKS_TRADEABLE_FROM;
+        });
+
+        afterEach(() => {
+            if (savedEnvVar === undefined) {
+                delete process.env.DRAFT_PICKS_TRADEABLE_FROM;
+            } else {
+                process.env.DRAFT_PICKS_TRADEABLE_FROM = savedEnvVar;
+            }
+        });
+
+        it("happy path — all filters produce the correct where/orderBy/pagination/include", async () => {
+            const someId = uuid();
+            const otherId = uuid();
+            const pick = makePick({ currentOwnerId: otherId, originalOwnerId: someId });
+            delete process.env.DRAFT_PICKS_TRADEABLE_FROM;
+
+            prisma.findMany.mockResolvedValueOnce([pick] as any);
+            prisma.count.mockResolvedValueOnce(1);
+
+            const result = await dao.searchEligiblePicks({
+                year: 2026,
+                type: PickLeagueLevel.MAJORS,
+                round: 1,
+                originalOwnerId: someId,
+                currentOwnerId: otherId,
+                skip: 0,
+                take: 10,
+            });
+
+            expect(prisma.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        season: 2026,
+                        type: PickLeagueLevel.MAJORS,
+                        round: expect.any(Object), // Prisma.Decimal
+                        originalOwnerId: someId,
+                        currentOwnerId: otherId,
+                    }),
+                    orderBy: [{ season: "desc" }, { round: "asc" }],
+                    skip: 0,
+                    take: 10,
+                    include: expectedInclude,
+                })
+            );
+            expect(result).toEqual({ picks: [pick], total: 1 });
+        });
+
+        it("partial filters — season and type only; round, ownerIds absent from where", async () => {
+            delete process.env.DRAFT_PICKS_TRADEABLE_FROM;
+
+            prisma.findMany.mockResolvedValueOnce([]);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.searchEligiblePicks({ year: 2026, type: PickLeagueLevel.MAJORS });
+
+            const callArg = prisma.findMany.mock.calls[0][0] as any;
+            expect(callArg.where).toEqual({ season: 2026, type: PickLeagueLevel.MAJORS });
+            expect(callArg.where).not.toHaveProperty("round");
+            expect(callArg.where).not.toHaveProperty("originalOwnerId");
+            expect(callArg.where).not.toHaveProperty("currentOwnerId");
+        });
+
+        it("no filters — where is empty object", async () => {
+            delete process.env.DRAFT_PICKS_TRADEABLE_FROM;
+
+            prisma.findMany.mockResolvedValueOnce([]);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.searchEligiblePicks({});
+
+            const callArg = prisma.findMany.mock.calls[0][0] as any;
+            expect(callArg.where).toEqual({});
+        });
+
+        it("default pagination — skip defaults to 0 and take defaults to 50 when omitted", async () => {
+            delete process.env.DRAFT_PICKS_TRADEABLE_FROM;
+
+            prisma.findMany.mockResolvedValueOnce([]);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.searchEligiblePicks({});
+
+            const callArg = prisma.findMany.mock.calls[0][0] as any;
+            expect(callArg.skip).toBe(0);
+            expect(callArg.take).toBe(50);
+        });
+
+        it("date gate — env var set to future date, returns early with empty result without calling findMany", async () => {
+            process.env.DRAFT_PICKS_TRADEABLE_FROM = "2099-01-01";
+
+            const result = await dao.searchEligiblePicks({});
+
+            expect(result).toEqual({ picks: [], total: 0 });
+            expect(prisma.findMany).not.toHaveBeenCalled();
+        });
+
+        it("date gate — env var set to past date, gate allows through and findMany is called", async () => {
+            process.env.DRAFT_PICKS_TRADEABLE_FROM = "2000-01-01";
+
+            prisma.findMany.mockResolvedValueOnce([]);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.searchEligiblePicks({});
+
+            expect(prisma.findMany).toHaveBeenCalled();
+        });
+
+        it("date gate — env var not set, gate is skipped and findMany is called", async () => {
+            delete process.env.DRAFT_PICKS_TRADEABLE_FROM;
+
+            prisma.findMany.mockResolvedValueOnce([]);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.searchEligiblePicks({});
+
+            expect(prisma.findMany).toHaveBeenCalled();
+        });
+
+        it("empty result — findMany returns [] and count returns 0", async () => {
+            delete process.env.DRAFT_PICKS_TRADEABLE_FROM;
+
+            prisma.findMany.mockResolvedValueOnce([]);
+            prisma.count.mockResolvedValueOnce(0);
+
+            const result = await dao.searchEligiblePicks({});
+
+            expect(result).toEqual({ picks: [], total: 0 });
+        });
+    });
 });

--- a/tests/unit/DAO/v2/PlayerDAO.test.ts
+++ b/tests/unit/DAO/v2/PlayerDAO.test.ts
@@ -194,6 +194,75 @@ describe("[PRISMA] PlayerDAO", () => {
         });
     });
 
+    describe("searchPlayers — ownerTeamIds filter", () => {
+        it("should filter by ownerTeamIds when provided", async () => {
+            const players = [makePlayer()];
+            prisma.findMany.mockResolvedValueOnce(players as any);
+            prisma.count.mockResolvedValueOnce(1);
+            const ownerTeamIds = [uuid(), uuid()];
+
+            const result = await dao.searchPlayers({ ownerTeamIds });
+
+            expect(prisma.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        leagueTeamId: { in: ownerTeamIds },
+                    }),
+                })
+            );
+            expect(prisma.count).toHaveBeenCalledWith({
+                where: expect.objectContaining({
+                    leagueTeamId: { in: ownerTeamIds },
+                }),
+            });
+            expect(result.players).toHaveLength(1);
+            expect(result.total).toBe(1);
+        });
+
+        it("should NOT include leagueTeamId filter when ownerTeamIds is empty", async () => {
+            prisma.findMany.mockResolvedValueOnce([]);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.searchPlayers({ ownerTeamIds: [] });
+
+            const callArg = prisma.findMany.mock.calls[0][0] as unknown as { where: Record<string, unknown> };
+            expect(callArg.where).not.toHaveProperty("leagueTeamId");
+        });
+
+        it("should NOT include leagueTeamId filter when ownerTeamIds is undefined", async () => {
+            prisma.findMany.mockResolvedValueOnce([]);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.searchPlayers({ ownerTeamIds: undefined });
+
+            const callArg = prisma.findMany.mock.calls[0][0] as unknown as { where: Record<string, unknown> };
+            expect(callArg.where).not.toHaveProperty("leagueTeamId");
+        });
+
+        it("should combine search, league, and ownerTeamIds filters simultaneously", async () => {
+            const player = makePlayer({ name: "Shohei Ohtani", league: PlayerLeagueLevel.MAJORS });
+            prisma.findMany.mockResolvedValueOnce([player] as any);
+            prisma.count.mockResolvedValueOnce(1);
+            const ownerTeamIds = [uuid()];
+
+            await dao.searchPlayers({
+                search: "ohtani",
+                league: PlayerLeagueLevel.MAJORS,
+                ownerTeamIds,
+            });
+
+            expect(prisma.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: {
+                        league: PlayerLeagueLevel.MAJORS,
+                        name: { contains: "ohtani", mode: "insensitive" },
+                        leagueTeamId: { in: ownerTeamIds },
+                    },
+                })
+            );
+        });
+    });
+
     describe("findPlayers", () => {
         it("should query with AND conditions from parsed params", async () => {
             prisma.findMany.mockResolvedValueOnce([]);

--- a/tests/unit/DAO/v2/TeamDAO.test.ts
+++ b/tests/unit/DAO/v2/TeamDAO.test.ts
@@ -120,4 +120,67 @@ describe("[PRISMA] TeamDAO", () => {
             expect(result.id).toBe(team.id);
         });
     });
+
+    describe("searchTeams", () => {
+        it("should search by name and owner csvName with correct query structure", async () => {
+            const teams = [makeTeam({ name: "Alpha Team" }), makeTeam({ name: "Alpha Wolves" })];
+            prisma.findMany.mockResolvedValueOnce(teams as any);
+
+            const result = await dao.searchTeams({ q: "Alpha" });
+
+            expect(prisma.findMany).toHaveBeenCalledWith({
+                where: {
+                    OR: [
+                        { name: { contains: "Alpha", mode: "insensitive" } },
+                        { owners: { some: { csvName: { contains: "Alpha", mode: "insensitive" } } } },
+                    ],
+                },
+                orderBy: { name: "asc" },
+                include: teamInclude,
+            });
+            expect(result).toHaveLength(2);
+        });
+
+        it("should include id notIn filter when excludeTeamIds is non-empty", async () => {
+            const team = makeTeam();
+            prisma.findMany.mockResolvedValueOnce([team] as any);
+            const excludeIds = ["id-to-exclude-1", "id-to-exclude-2"];
+
+            await dao.searchTeams({ q: "Squad", excludeTeamIds: excludeIds });
+
+            expect(prisma.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        id: { notIn: excludeIds },
+                    }),
+                })
+            );
+        });
+
+        it("should NOT include id filter when excludeTeamIds is empty", async () => {
+            prisma.findMany.mockResolvedValueOnce([]);
+
+            await dao.searchTeams({ q: "Squad", excludeTeamIds: [] });
+
+            const callArg = prisma.findMany.mock.calls[0][0] as unknown as { where: Record<string, unknown> };
+            expect(callArg.where).not.toHaveProperty("id");
+        });
+
+        it("should NOT include id filter when excludeTeamIds is omitted", async () => {
+            prisma.findMany.mockResolvedValueOnce([]);
+
+            await dao.searchTeams({ q: "Squad" });
+
+            const callArg = prisma.findMany.mock.calls[0][0] as unknown as { where: Record<string, unknown> };
+            expect(callArg.where).not.toHaveProperty("id");
+        });
+
+        it("should return an empty array when no teams match", async () => {
+            prisma.findMany.mockResolvedValueOnce([]);
+
+            const result = await dao.searchTeams({ q: "ZZZNoMatch" });
+
+            expect(result).toEqual([]);
+        });
+    });
 });

--- a/tests/unit/DAO/v2/TradeDAO.test.ts
+++ b/tests/unit/DAO/v2/TradeDAO.test.ts
@@ -1,6 +1,11 @@
-import { PrismaClient, TradeItemType, TradeStatus } from "@prisma/client";
+import { PrismaClient, TradeItemType, TradeParticipantType, TradeStatus } from "@prisma/client";
 import { mockClear, mockDeep } from "jest-mock-extended";
-import TradeDAO, { AcceptedByEntry, buildStaffTradeWhere, resolvePickIds } from "../../../../src/DAO/v2/TradeDAO";
+import TradeDAO, {
+    AcceptedByEntry,
+    buildStaffTradeWhere,
+    resolvePickIds,
+    tradeWithRelations,
+} from "../../../../src/DAO/v2/TradeDAO";
 import { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
 import { TradeFactory } from "../../../factories/TradeFactory";
 import { daoTestLifecycle, expectDaoRequiresPrismaClient } from "./daoTestHelpers";
@@ -11,6 +16,7 @@ const makeMinimalTrade = (...args: Parameters<typeof TradeFactory.getPrismaTrade
 
 describe("[PRISMA] TradeDAO", () => {
     const prisma = mockDeep<PrismaClient["trade"]>();
+    const tradeItemDb = mockDeep<ExtendedPrismaClient["tradeItem"]>();
     const dao = new TradeDAO(prisma as unknown as ExtendedPrismaClient["trade"]);
     const tradeId = uuid();
     const testTrade = makeMinimalTrade({ id: tradeId });
@@ -18,6 +24,7 @@ describe("[PRISMA] TradeDAO", () => {
     daoTestLifecycle("TRADE");
     afterEach(() => {
         mockClear(prisma);
+        mockClear(tradeItemDb);
     });
 
     expectDaoRequiresPrismaClient(TradeDAO, "TradeDAO");
@@ -586,6 +593,450 @@ describe("[PRISMA] TradeDAO", () => {
             expect(call.where).toHaveProperty("status", { in: [TradeStatus.SUBMITTED] });
             expect(call.where).toHaveProperty("acceptedOnDate");
             expect(call.where).toHaveProperty("AND");
+        });
+    });
+
+    // ─── New draft/trade-item methods ────────────────────────────────────────────
+
+    describe("createDraft", () => {
+        it("should call prisma.create with DRAFT status, CREATOR participant, and RECIPIENT participants", async () => {
+            const creatorTeamId = uuid();
+            const recipientTeamId1 = uuid();
+            const recipientTeamId2 = uuid();
+            const createdTrade = makeMinimalTrade({ id: tradeId });
+
+            prisma.create.mockResolvedValueOnce(createdTrade as any);
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(createdTrade as any);
+
+            await dao.createDraft({ creatorTeamId, participantTeamIds: [recipientTeamId1, recipientTeamId2] });
+
+            expect(prisma.create).toHaveBeenCalledTimes(1);
+            expect(prisma.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        status: TradeStatus.DRAFT,
+                        tradeParticipants: expect.objectContaining({
+                            create: expect.arrayContaining([
+                                expect.objectContaining({
+                                    participantType: TradeParticipantType.CREATOR,
+                                    teamId: creatorTeamId,
+                                }),
+                                expect.objectContaining({
+                                    participantType: TradeParticipantType.RECIPIENT,
+                                    teamId: recipientTeamId1,
+                                }),
+                                expect.objectContaining({
+                                    participantType: TradeParticipantType.RECIPIENT,
+                                    teamId: recipientTeamId2,
+                                }),
+                            ]),
+                        }),
+                    }),
+                })
+            );
+
+            expect(prisma.findUniqueOrThrow).toHaveBeenCalledWith(
+                expect.objectContaining({ where: { id: createdTrade.id } })
+            );
+        });
+
+        it("should create with only CREATOR participant when participantTeamIds is empty", async () => {
+            const creatorTeamId = uuid();
+            const createdTrade = makeMinimalTrade({ id: tradeId });
+
+            prisma.create.mockResolvedValueOnce(createdTrade as any);
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(createdTrade as any);
+
+            await dao.createDraft({ creatorTeamId, participantTeamIds: [] });
+
+            expect(prisma.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        status: TradeStatus.DRAFT,
+                        tradeParticipants: expect.objectContaining({
+                            create: [
+                                expect.objectContaining({
+                                    participantType: TradeParticipantType.CREATOR,
+                                    teamId: creatorTeamId,
+                                }),
+                            ],
+                        }),
+                    }),
+                })
+            );
+        });
+    });
+
+    describe("updateDraftParticipants", () => {
+        it("should deleteMany RECIPIENT participants and create new ones, then hydrate", async () => {
+            const newRecipientId1 = uuid();
+            const newRecipientId2 = uuid();
+
+            prisma.update.mockResolvedValueOnce(testTrade as any);
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(testTrade as any);
+
+            await dao.updateDraftParticipants(tradeId, [newRecipientId1, newRecipientId2]);
+
+            expect(prisma.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { id: tradeId },
+                    data: expect.objectContaining({
+                        tradeParticipants: expect.objectContaining({
+                            deleteMany: { participantType: TradeParticipantType.RECIPIENT },
+                            create: expect.arrayContaining([
+                                expect.objectContaining({
+                                    participantType: TradeParticipantType.RECIPIENT,
+                                    teamId: newRecipientId1,
+                                }),
+                                expect.objectContaining({
+                                    participantType: TradeParticipantType.RECIPIENT,
+                                    teamId: newRecipientId2,
+                                }),
+                            ]),
+                        }),
+                    }),
+                })
+            );
+
+            expect(prisma.findUniqueOrThrow).toHaveBeenCalledWith(expect.objectContaining({ where: { id: tradeId } }));
+        });
+
+        it("should call deleteMany with no create entries when recipientTeamIds is empty", async () => {
+            prisma.update.mockResolvedValueOnce(testTrade as any);
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(testTrade as any);
+
+            await dao.updateDraftParticipants(tradeId, []);
+
+            expect(prisma.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        tradeParticipants: expect.objectContaining({
+                            deleteMany: { participantType: TradeParticipantType.RECIPIENT },
+                            create: [],
+                        }),
+                    }),
+                })
+            );
+        });
+    });
+
+    describe("addTradeItem", () => {
+        it("should call prisma.update with tradeItems.create containing all fields, then hydrate", async () => {
+            const itemId = uuid();
+            const senderId = uuid();
+            const recipientId = uuid();
+
+            prisma.update.mockResolvedValueOnce(testTrade as any);
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(testTrade as any);
+
+            await dao.addTradeItem(tradeId, {
+                tradeItemType: TradeItemType.PLAYER,
+                tradeItemId: itemId,
+                senderId,
+                recipientId,
+            });
+
+            expect(prisma.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { id: tradeId },
+                    data: expect.objectContaining({
+                        tradeItems: expect.objectContaining({
+                            create: expect.objectContaining({
+                                tradeItemType: TradeItemType.PLAYER,
+                                tradeItemId: itemId,
+                                senderId,
+                                recipientId,
+                            }),
+                        }),
+                    }),
+                })
+            );
+
+            expect(prisma.findUniqueOrThrow).toHaveBeenCalledWith(expect.objectContaining({ where: { id: tradeId } }));
+        });
+
+        it("should pass the PICK tradeItemType to the create data", async () => {
+            const itemId = uuid();
+            const senderId = uuid();
+            const recipientId = uuid();
+
+            prisma.update.mockResolvedValueOnce(testTrade as any);
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(testTrade as any);
+
+            await dao.addTradeItem(tradeId, {
+                tradeItemType: TradeItemType.PICK,
+                tradeItemId: itemId,
+                senderId,
+                recipientId,
+            });
+
+            expect(prisma.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        tradeItems: expect.objectContaining({
+                            create: expect.objectContaining({
+                                tradeItemType: TradeItemType.PICK,
+                                tradeItemId: itemId,
+                            }),
+                        }),
+                    }),
+                })
+            );
+        });
+    });
+
+    describe("updateTradeItem", () => {
+        it("should update tradeItem by lineId and hydrate via tradeId", async () => {
+            const lineId = uuid();
+            const senderId = uuid();
+            const recipientId = uuid();
+            const updatedItem = { id: lineId, tradeId };
+
+            tradeItemDb.update.mockResolvedValueOnce(updatedItem as any);
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(testTrade as any);
+
+            await dao.updateTradeItem(
+                lineId,
+                { senderId, recipientId },
+                tradeItemDb as unknown as ExtendedPrismaClient["tradeItem"]
+            );
+
+            expect(tradeItemDb.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { id: lineId },
+                    data: expect.objectContaining({ senderId, recipientId }),
+                })
+            );
+
+            expect(prisma.findUniqueOrThrow).toHaveBeenCalledWith(expect.objectContaining({ where: { id: tradeId } }));
+        });
+
+        it("should work with a partial update (senderId only)", async () => {
+            const lineId = uuid();
+            const senderId = uuid();
+            const updatedItem = { id: lineId, tradeId };
+
+            tradeItemDb.update.mockResolvedValueOnce(updatedItem as any);
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(testTrade as any);
+
+            await dao.updateTradeItem(
+                lineId,
+                { senderId },
+                tradeItemDb as unknown as ExtendedPrismaClient["tradeItem"]
+            );
+
+            expect(tradeItemDb.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({ senderId }),
+                })
+            );
+        });
+
+        it("should throw when updated tradeItem has no tradeId", async () => {
+            const lineId = uuid();
+            const updatedItem = { id: lineId, tradeId: null };
+
+            tradeItemDb.update.mockResolvedValueOnce(updatedItem as any);
+
+            await expect(
+                dao.updateTradeItem(
+                    lineId,
+                    { senderId: uuid() },
+                    tradeItemDb as unknown as ExtendedPrismaClient["tradeItem"]
+                )
+            ).rejects.toThrow();
+
+            expect(prisma.findUniqueOrThrow).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("removeTradeItem", () => {
+        it("should find tradeItem, delete it, then hydrate via tradeId", async () => {
+            const lineId = uuid();
+
+            tradeItemDb.findUniqueOrThrow.mockResolvedValueOnce({ tradeId } as any);
+            tradeItemDb.delete.mockResolvedValueOnce({} as any);
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(testTrade as any);
+
+            await dao.removeTradeItem(lineId, tradeItemDb as unknown as ExtendedPrismaClient["tradeItem"]);
+
+            expect(tradeItemDb.findUniqueOrThrow).toHaveBeenCalledWith(
+                expect.objectContaining({ where: { id: lineId } })
+            );
+            expect(tradeItemDb.delete).toHaveBeenCalledWith(expect.objectContaining({ where: { id: lineId } }));
+            expect(prisma.findUniqueOrThrow).toHaveBeenCalledWith(expect.objectContaining({ where: { id: tradeId } }));
+        });
+
+        it("should propagate error when tradeItem is not found", async () => {
+            const lineId = uuid();
+
+            tradeItemDb.findUniqueOrThrow.mockRejectedValueOnce(new Error("Record not found"));
+
+            await expect(
+                dao.removeTradeItem(lineId, tradeItemDb as unknown as ExtendedPrismaClient["tradeItem"])
+            ).rejects.toThrow("Record not found");
+
+            expect(tradeItemDb.delete).not.toHaveBeenCalled();
+            expect(prisma.findUniqueOrThrow).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("deleteDraft", () => {
+        const ownerId = uuid();
+        const creatorTeamId = uuid();
+
+        const makeDraftTradeWithOwner = (
+            overrides: Partial<{ status: TradeStatus; participantType: TradeParticipantType; ownerId: string }> = {}
+        ) => {
+            const participantType = overrides.participantType ?? TradeParticipantType.CREATOR;
+            const ownerIdToUse = overrides.ownerId ?? ownerId;
+            const status = overrides.status ?? TradeStatus.DRAFT;
+            return {
+                id: tradeId,
+                status,
+                tradeParticipants: [
+                    {
+                        participantType,
+                        teamId: creatorTeamId,
+                        team: {
+                            id: creatorTeamId,
+                            owners: [{ id: ownerIdToUse }],
+                        },
+                    },
+                ],
+                tradeItems: [],
+                emails: [],
+            };
+        };
+
+        it("should delete the trade when status is DRAFT and user is an owner of the creator team", async () => {
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(makeDraftTradeWithOwner() as any);
+            prisma.delete.mockResolvedValueOnce(testTrade as any);
+
+            await dao.deleteDraft(tradeId, ownerId);
+
+            expect(prisma.delete).toHaveBeenCalledWith({ where: { id: tradeId } });
+        });
+
+        it("should throw when trade status is not DRAFT", async () => {
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(
+                makeDraftTradeWithOwner({ status: TradeStatus.REQUESTED }) as any
+            );
+
+            await expect(dao.deleteDraft(tradeId, ownerId)).rejects.toThrow();
+
+            expect(prisma.delete).not.toHaveBeenCalled();
+        });
+
+        it("should throw when user is not an owner of the creator team", async () => {
+            const differentOwnerId = uuid();
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(
+                makeDraftTradeWithOwner({ ownerId: differentOwnerId }) as any
+            );
+
+            await expect(dao.deleteDraft(tradeId, ownerId)).rejects.toThrow();
+
+            expect(prisma.delete).not.toHaveBeenCalled();
+        });
+
+        it("should throw when no CREATOR participant exists", async () => {
+            const tradeWithNoCreator = {
+                id: tradeId,
+                status: TradeStatus.DRAFT,
+                tradeParticipants: [
+                    {
+                        participantType: TradeParticipantType.RECIPIENT,
+                        teamId: uuid(),
+                        team: { id: uuid(), owners: [{ id: ownerId }] },
+                    },
+                ],
+                tradeItems: [],
+                emails: [],
+            };
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(tradeWithNoCreator as any);
+
+            await expect(dao.deleteDraft(tradeId, ownerId)).rejects.toThrow();
+
+            expect(prisma.delete).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("listDraftsForUser", () => {
+        it("should query by team ids with DRAFT status, paginate, and return count", async () => {
+            const teamIds = [uuid(), uuid()];
+            const tradeA = makeMinimalTrade({ id: uuid(), status: TradeStatus.DRAFT });
+            const tradeB = makeMinimalTrade({ id: uuid(), status: TradeStatus.DRAFT });
+
+            prisma.findMany.mockResolvedValueOnce([tradeA, tradeB] as any);
+            prisma.count.mockResolvedValueOnce(2);
+
+            const result = await dao.listDraftsForUser({ teamIds, skip: 0, take: 10 });
+
+            expect(prisma.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        tradeParticipants: { some: { teamId: { in: teamIds } } },
+                        status: TradeStatus.DRAFT,
+                    }),
+                    skip: 0,
+                    take: 10,
+                })
+            );
+
+            expect(prisma.count).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({
+                        status: TradeStatus.DRAFT,
+                    }),
+                })
+            );
+
+            expect(result).toEqual({ trades: [tradeA, tradeB], total: 2 });
+        });
+
+        it("should calculate skip based on page and pageSize", async () => {
+            const teamIds = [uuid()];
+
+            prisma.findMany.mockResolvedValueOnce([] as any);
+            prisma.count.mockResolvedValueOnce(0);
+
+            await dao.listDraftsForUser({ teamIds, skip: 10, take: 5 });
+
+            expect(prisma.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    skip: 10,
+                    take: 5,
+                })
+            );
+        });
+    });
+
+    describe("requestTrade", () => {
+        it("should transition DRAFT trade to REQUESTED status and return hydrated trade", async () => {
+            prisma.findUniqueOrThrow.mockResolvedValueOnce({ status: TradeStatus.DRAFT } as any);
+            prisma.update.mockResolvedValueOnce(testTrade as any);
+            prisma.findUniqueOrThrow.mockResolvedValueOnce(testTrade as any);
+
+            const result = await dao.requestTrade(tradeId);
+
+            expect(prisma.update).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { id: tradeId },
+                    data: expect.objectContaining({ status: TradeStatus.REQUESTED }),
+                })
+            );
+
+            // Second findUniqueOrThrow is the hydration call
+            expect(prisma.findUniqueOrThrow).toHaveBeenCalledTimes(2);
+            expect(result).toEqual(testTrade);
+        });
+
+        it("should throw when trade status is not DRAFT", async () => {
+            prisma.findUniqueOrThrow.mockResolvedValueOnce({ status: TradeStatus.REQUESTED } as any);
+
+            await expect(dao.requestTrade(tradeId)).rejects.toThrow();
+
+            expect(prisma.update).not.toHaveBeenCalled();
         });
     });
 });

--- a/tests/unit/services/tradeBuilder/notificationPrefs.test.ts
+++ b/tests/unit/services/tradeBuilder/notificationPrefs.test.ts
@@ -1,0 +1,91 @@
+import { willNotifyVia } from "../../../../src/services/tradeBuilder/notificationPrefs";
+import { v4 as uuid } from "uuid";
+import type { ExtendedPrismaClient } from "../../../../src/bootstrap/prisma-db";
+
+// mockDeep<ExtendedPrismaClient["user"]>() triggers a ts-jest internal assertion on the
+// deeply overloaded Prisma extended-client type. Use a minimal typed stub instead;
+// findUnique is the only method exercised by willNotifyVia.
+const mockFindUnique = jest.fn();
+const userDb = { findUnique: mockFindUnique } as unknown as ExtendedPrismaClient["user"];
+
+afterEach(() => {
+    mockFindUnique.mockClear();
+});
+
+function makeUserRow(overrides: { discordUserId?: string | null; userSettings?: Record<string, unknown> | null } = {}) {
+    return {
+        id: uuid(),
+        discordUserId: overrides.discordUserId ?? null,
+        userSettings: overrides.userSettings ?? null,
+    };
+}
+
+describe("unit/ willNotifyVia", () => {
+    it("email enabled by default when userSettings is empty", async () => {
+        const user = makeUserRow({ userSettings: {} });
+        mockFindUnique.mockResolvedValueOnce(user);
+
+        const result = await willNotifyVia(user.id, userDb);
+
+        expect(result.email).toBe(true);
+        expect(result.discordDm).toBe(false);
+        expect(result.discordUserId).toBeNull();
+    });
+
+    it("Discord DM enabled when discordUserId present and setting is true", async () => {
+        const user = makeUserRow({
+            discordUserId: "1234567890",
+            userSettings: { notifications: { tradeActionDiscordDm: true } },
+        });
+        mockFindUnique.mockResolvedValueOnce(user);
+
+        const result = await willNotifyVia(user.id, userDb);
+
+        expect(result.discordDm).toBe(true);
+        expect(result.discordUserId).toBe("1234567890");
+    });
+
+    it("Discord DM disabled when setting is explicitly false", async () => {
+        const user = makeUserRow({
+            discordUserId: "1234",
+            userSettings: { notifications: { tradeActionDiscordDm: false } },
+        });
+        mockFindUnique.mockResolvedValueOnce(user);
+
+        const result = await willNotifyVia(user.id, userDb);
+
+        expect(result.discordDm).toBe(false);
+    });
+
+    it("Discord DM false when discordUserId is null even if setting is true", async () => {
+        const user = makeUserRow({
+            discordUserId: null,
+            userSettings: { notifications: { tradeActionDiscordDm: true } },
+        });
+        mockFindUnique.mockResolvedValueOnce(user);
+
+        const result = await willNotifyVia(user.id, userDb);
+
+        expect(result.discordDm).toBe(false);
+        expect(result.discordUserId).toBeNull();
+    });
+
+    it("user not found — all channels false", async () => {
+        mockFindUnique.mockResolvedValueOnce(null);
+
+        const result = await willNotifyVia(uuid(), userDb);
+
+        expect(result).toEqual({ email: false, discordDm: false, discordUserId: null });
+    });
+
+    it("email explicitly disabled via settings", async () => {
+        const user = makeUserRow({
+            userSettings: { notifications: { tradeActionEmail: false } },
+        });
+        mockFindUnique.mockResolvedValueOnce(user);
+
+        const result = await willNotifyVia(user.id, userDb);
+
+        expect(result.email).toBe(false);
+    });
+});

--- a/tests/unit/services/tradeBuilder/tradeValidator.test.ts
+++ b/tests/unit/services/tradeBuilder/tradeValidator.test.ts
@@ -1,0 +1,274 @@
+import { mockDeep, mockClear } from "jest-mock-extended";
+import { TradeParticipantType } from "@prisma/client";
+import TradeDAO from "../../../../src/DAO/v2/TradeDAO";
+import { buildTradeSummary, validateTrade } from "../../../../src/services/tradeBuilder/tradeValidator";
+import { TradeFactory } from "../../../factories/TradeFactory";
+import { v4 as uuid } from "uuid";
+import type { PrismaTrade } from "../../../../src/DAO/v2/TradeDAO";
+
+// ─── Inline helpers ───────────────────────────────────────────────────────────
+
+// Produces the minimal participant shape that tradeValidator reads:
+// participantType, teamId, team.name, team.owners
+function makeParticipant(
+    teamId: string,
+    type: TradeParticipantType,
+    ownerIds: string[] = []
+): PrismaTrade["tradeParticipants"][number] {
+    return {
+        id: uuid(),
+        tradeId: uuid(),
+        participantType: type,
+        teamId,
+        team: {
+            id: teamId,
+            name: `Team-${teamId.slice(0, 4)}`,
+            owners: ownerIds.map(oid => ({
+                id: oid,
+                name: "Owner",
+                email: `${oid}@example.com`,
+                password: "hashed",
+                userSettings: null,
+                discordUserId: null,
+                dateCreated: new Date(),
+                dateModified: new Date(),
+            })),
+            espnId: null,
+            slackId: null,
+            dateCreated: new Date(),
+            dateModified: new Date(),
+        },
+    } as unknown as PrismaTrade["tradeParticipants"][number];
+}
+
+// Produces the minimal trade-item shape that tradeValidator reads: senderId / recipientId
+function makeTradeItem(senderId: string, recipientId: string): PrismaTrade["tradeItems"][number] {
+    return {
+        id: uuid(),
+        tradeId: uuid(),
+        tradeItemType: "PLAYER" as const,
+        tradeItemId: uuid(),
+        senderId,
+        recipientId,
+        sender: null,
+        recipient: null,
+    } as unknown as PrismaTrade["tradeItems"][number];
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe("unit/ tradeValidator", () => {
+    const mockDao = mockDeep<TradeDAO>();
+
+    afterEach(() => {
+        mockClear(mockDao);
+    });
+
+    // ── buildTradeSummary ─────────────────────────────────────────────────────
+
+    describe("buildTradeSummary", () => {
+        it("happy path — 2 teams, items sent both ways", async () => {
+            const creatorTeamId = uuid();
+            const recipientTeamId = uuid();
+
+            const trade = TradeFactory.getPrismaTrade({
+                tradeParticipants: [
+                    makeParticipant(creatorTeamId, TradeParticipantType.CREATOR),
+                    makeParticipant(recipientTeamId, TradeParticipantType.RECIPIENT),
+                ],
+                tradeItems: [
+                    makeTradeItem(creatorTeamId, recipientTeamId), // creator sends to recipient
+                    makeTradeItem(recipientTeamId, creatorTeamId), // recipient sends to creator
+                ],
+            });
+
+            mockDao.getTradeById.mockResolvedValueOnce(trade);
+
+            const summary = await buildTradeSummary(trade.id, mockDao);
+
+            expect(summary.teams).toHaveLength(2);
+
+            const creator = summary.teams.find(t => t.teamId === creatorTeamId)!;
+            const recipient = summary.teams.find(t => t.teamId === recipientTeamId)!;
+
+            expect(creator.sendsCount).toBe(1);
+            expect(creator.receivesCount).toBe(1);
+            expect(recipient.sendsCount).toBe(1);
+            expect(recipient.receivesCount).toBe(1);
+        });
+
+        it("no items — all counts are 0", async () => {
+            const creatorTeamId = uuid();
+            const recipientTeamId = uuid();
+
+            const trade = TradeFactory.getPrismaTrade({
+                tradeParticipants: [
+                    makeParticipant(creatorTeamId, TradeParticipantType.CREATOR),
+                    makeParticipant(recipientTeamId, TradeParticipantType.RECIPIENT),
+                ],
+                tradeItems: [],
+            });
+
+            mockDao.getTradeById.mockResolvedValueOnce(trade);
+
+            const summary = await buildTradeSummary(trade.id, mockDao);
+
+            for (const team of summary.teams) {
+                expect(team.sendsCount).toBe(0);
+                expect(team.receivesCount).toBe(0);
+            }
+        });
+    });
+
+    // ── validateTrade ─────────────────────────────────────────────────────────
+
+    describe("validateTrade", () => {
+        it("valid trade — canSend: true, no errors, no warnings", async () => {
+            const creatorTeamId = uuid();
+            const recipientTeamId = uuid();
+
+            const trade = TradeFactory.getPrismaTrade({
+                tradeParticipants: [
+                    makeParticipant(creatorTeamId, TradeParticipantType.CREATOR),
+                    makeParticipant(recipientTeamId, TradeParticipantType.RECIPIENT),
+                ],
+                tradeItems: [
+                    makeTradeItem(creatorTeamId, recipientTeamId), // creator sends to recipient
+                    makeTradeItem(recipientTeamId, creatorTeamId), // recipient sends to creator
+                ],
+            });
+
+            mockDao.getTradeById.mockResolvedValueOnce(trade);
+
+            const result = await validateTrade(trade.id, mockDao);
+
+            expect(result.canSend).toBe(true);
+            expect(result.errors).toHaveLength(0);
+            expect(result.warnings).toHaveLength(0);
+        });
+
+        it("MISSING_CREATOR — no CREATOR participant", async () => {
+            const recipientTeamId = uuid();
+
+            const trade = TradeFactory.getPrismaTrade({
+                tradeParticipants: [makeParticipant(recipientTeamId, TradeParticipantType.RECIPIENT)],
+                tradeItems: [makeTradeItem(recipientTeamId, recipientTeamId)],
+            });
+
+            mockDao.getTradeById.mockResolvedValueOnce(trade);
+
+            const result = await validateTrade(trade.id, mockDao);
+
+            expect(result.canSend).toBe(false);
+            expect(result.errors.map(e => e.code)).toContain("MISSING_CREATOR");
+        });
+
+        it("MULTIPLE_CREATORS — two CREATOR participants", async () => {
+            const creatorTeamId1 = uuid();
+            const creatorTeamId2 = uuid();
+            const recipientTeamId = uuid();
+
+            const trade = TradeFactory.getPrismaTrade({
+                tradeParticipants: [
+                    makeParticipant(creatorTeamId1, TradeParticipantType.CREATOR),
+                    makeParticipant(creatorTeamId2, TradeParticipantType.CREATOR),
+                    makeParticipant(recipientTeamId, TradeParticipantType.RECIPIENT),
+                ],
+                tradeItems: [makeTradeItem(creatorTeamId1, recipientTeamId)],
+            });
+
+            mockDao.getTradeById.mockResolvedValueOnce(trade);
+
+            const result = await validateTrade(trade.id, mockDao);
+
+            expect(result.canSend).toBe(false);
+            expect(result.errors.map(e => e.code)).toContain("MULTIPLE_CREATORS");
+        });
+
+        it("NO_RECIPIENTS — no RECIPIENT participant", async () => {
+            const creatorTeamId = uuid();
+
+            const trade = TradeFactory.getPrismaTrade({
+                tradeParticipants: [makeParticipant(creatorTeamId, TradeParticipantType.CREATOR)],
+                tradeItems: [makeTradeItem(creatorTeamId, creatorTeamId)],
+            });
+
+            mockDao.getTradeById.mockResolvedValueOnce(trade);
+
+            const result = await validateTrade(trade.id, mockDao);
+
+            expect(result.errors.map(e => e.code)).toContain("NO_RECIPIENTS");
+        });
+
+        it("NO_TRADE_ITEMS — no trade items", async () => {
+            const creatorTeamId = uuid();
+            const recipientTeamId = uuid();
+
+            const trade = TradeFactory.getPrismaTrade({
+                tradeParticipants: [
+                    makeParticipant(creatorTeamId, TradeParticipantType.CREATOR),
+                    makeParticipant(recipientTeamId, TradeParticipantType.RECIPIENT),
+                ],
+                tradeItems: [],
+            });
+
+            mockDao.getTradeById.mockResolvedValueOnce(trade);
+
+            const result = await validateTrade(trade.id, mockDao);
+
+            expect(result.errors.map(e => e.code)).toContain("NO_TRADE_ITEMS");
+        });
+
+        it("TEAM_RECEIVES_NOTHING warning — second recipient gets nothing, canSend stays true", async () => {
+            const creatorTeamId = uuid();
+            const recipientTeamId1 = uuid();
+            const recipientTeamId2 = uuid();
+
+            const trade = TradeFactory.getPrismaTrade({
+                tradeParticipants: [
+                    makeParticipant(creatorTeamId, TradeParticipantType.CREATOR),
+                    makeParticipant(recipientTeamId1, TradeParticipantType.RECIPIENT),
+                    makeParticipant(recipientTeamId2, TradeParticipantType.RECIPIENT),
+                ],
+                tradeItems: [
+                    // Only recipientTeamId1 receives something
+                    makeTradeItem(creatorTeamId, recipientTeamId1),
+                ],
+            });
+
+            mockDao.getTradeById.mockResolvedValueOnce(trade);
+
+            const result = await validateTrade(trade.id, mockDao);
+
+            // A warning is advisory — canSend must still be true
+            expect(result.canSend).toBe(true);
+            expect(result.errors).toHaveLength(0);
+
+            expect(result.warnings.map(w => w.code)).toContain("TEAM_RECEIVES_NOTHING");
+
+            const nothingWarning = result.warnings.find(
+                w => w.code === "TEAM_RECEIVES_NOTHING" && w.teamId === recipientTeamId2
+            );
+            expect(nothingWarning).toBeDefined();
+        });
+
+        it("calls getTradeById exactly once per validateTrade call", async () => {
+            const creatorTeamId = uuid();
+            const recipientTeamId = uuid();
+
+            const trade = TradeFactory.getPrismaTrade({
+                tradeParticipants: [
+                    makeParticipant(creatorTeamId, TradeParticipantType.CREATOR),
+                    makeParticipant(recipientTeamId, TradeParticipantType.RECIPIENT),
+                ],
+                tradeItems: [makeTradeItem(creatorTeamId, recipientTeamId)],
+            });
+
+            mockDao.getTradeById.mockResolvedValueOnce(trade);
+
+            await validateTrade(trade.id, mockDao);
+
+            expect(mockDao.getTradeById).toHaveBeenCalledTimes(1);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Implements all zero-migration v2 DAO additions scoped in [ADR 0003](docs/adr/0003-trade-builder-v2-daos.md) to unblock the Trade Request Builder UI.

### TradeDAO — builder writes
- `createDraft({ creatorTeamId, participantTeamIds })` — DRAFT trade + participants
- `updateDraftParticipants(tradeId, participantTeamIds)` — reconcile recipient set
- `addTradeItem(tradeId, { tradeItemType, tradeItemId, senderId, recipientId })` — `@@unique` dedup
- `updateTradeItem(lineId, updates, tradeItemDb)` — reroute a line
- `removeTradeItem(lineId, tradeItemDb)` — remove a line
- `deleteDraft(tradeId, requestingUserId)` — **authz guard**: must own CREATOR team + status DRAFT
- `listDraftsForUser({ teamIds, skip, take, sort? })` — DRAFT-scoped listing
- `requestTrade(tradeId)` — DRAFT→REQUESTED transition; notification enqueueing is caller's responsibility

### Search / lookup
- `TeamDAO.searchTeams({ q, excludeTeamIds? })` — OR match on Team.name + owners[].csvName; CSV-weighted ranking in app code
- `PlayerDAO.searchPlayers` — new `ownerTeamIds[]` filter via indexed `Player.leagueTeamId`
- `DraftPickDAO.searchEligiblePicks({ year, type, round, originalOwnerId, currentOwnerId, skip, take })` — env-var date gate (`DRAFT_PICKS_TRADEABLE_FROM`); no Settings table lookup

### Validation service (`src/services/tradeBuilder/`)
- `buildTradeSummary(tradeId, tradeDao)` — single source of truth for per-team sends/receives counts (used by both /validate and /review so counts are guaranteed consistent)
- `validateTrade(tradeId, tradeDao)` — structural checks: MISSING_CREATOR, MULTIPLE_CREATORS, NO_RECIPIENTS, NO_TRADE_ITEMS errors; TEAM_RECEIVES_NOTHING warning
- `willNotifyVia(userId, userDb)` — reads emailEnabled / discordDmEnabled + discordUserId presence

### Explicitly NOT implemented (per ADR)
`bulkMutateTradeItems`, roster-cap validation, pick encumbrance, Settings-backed pick trade date, position filtering, optimistic concurrency, Trade.title, leagueId scoping.

### tRPC wiring
Out of scope — frontend procedure wiring is a separate ticket. These DAOs are ready to plug in.

## Test coverage
- **Unit tests**: 132 passing across all new DAO methods and services (extended existing test files + new `tests/unit/services/tradeBuilder/`)
- **Integration tests** (DAO-level, real DB, no HTTP): 18 passing in `tests/integration/v2/db/`
  - `TradeDAO`: createDraft→addTradeItem→requestTrade round-trip, dedup constraint, deleteDraft authz guards
  - `TeamDAO`: name match, owner csvName match, excludeTeamIds, OR logic
  - `DraftPickDAO`: single/multi-column filters, owner filter, empty result, pagination
  - `TradeValidator`: per-team send/receive counts, valid trade, NO_TRADE_ITEMS error, TEAM_RECEIVES_NOTHING warning
- **fullcheck**: lint + typecheck + format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)